### PR TITLE
Feature: Object support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,48 +85,105 @@ For running JMH tests just execute:
 ./gradlew jmh
 ```
 
-Results for `FastutilWrapper BusyWaiting mode` vs `FastutilWrapper Default mode` vs [java.util wrappers](https://docs.oracle.com/javase/tutorial/collections/implementations/wrapper.html)
+Results for `FastutilWrapper BusyWaiting mode` vs `FastutilWrapper Default mode` vs [java.util wrappers](https://docs.oracle.com/javase/tutorial/collections/implementations/wrapper.html) vs [java.util.concurrent](https://docs.oracle.com/javase/tutorial/collections/implementations/map.html)
+
+#### LongLongMap
 
 Throughput (more is better)
 
 ```shell
-Benchmark                                                        Mode  Cnt         Score         Error  Units
+Benchmark                                                                Mode  Cnt          Score         Error  Units
 
-FastutilWrapperBusyWaitingBenchmark.testRandomAllOpsThroughput  thrpt   15  14517457,055 ?  795637,784  ops/s
-FastutilWrapperBusyWaitingBenchmark.testRandomGetThroughput     thrpt   15  16610181,320 ? 1456776,589  ops/s
-FastutilWrapperBusyWaitingBenchmark.testRandomPutThroughput     thrpt   13  11706178,916 ? 2547333,524  ops/s
+FastutilWrapperBusyWaitingLongLongBenchmark.testRandomAllOpsThroughput  thrpt   15   14890349.957 ± 2041249.822  ops/s
+FastutilWrapperBusyWaitingLongLongBenchmark.testRandomGetThroughput     thrpt   15   25449527.963 ± 2600729.022  ops/s
+FastutilWrapperBusyWaitingLongLongBenchmark.testRandomPutThroughput     thrpt   14   11351650.286 ± 3324513.684  ops/s
 
-FastutilWrapperDefaultBenchmark.testRandomAllOpsThroughput      thrpt   15   7385357,514 ? 1127356,032  ops/s
-FastutilWrapperDefaultBenchmark.testRandomGetThroughput         thrpt   15  16190621,923 ? 1836415,022  ops/s
-FastutilWrapperDefaultBenchmark.testRandomPutThroughput         thrpt   15   8945369,395 ? 1225460,217  ops/s
+FastutilWrapperDefaultLongLongBenchmark.testRandomAllOpsThroughput      thrpt   15    9241548.296 ± 1501812.910  ops/s
+FastutilWrapperDefaultLongLongBenchmark.testRandomGetThroughput         thrpt   15   23205312.991 ± 2243533.089  ops/s
+FastutilWrapperDefaultLongLongBenchmark.testRandomPutThroughput         thrpt   15    8705378.516 ± 2193254.025  ops/s
 
-JavaUtilWrapperBenchmark.testRandomAllOpsThroughput             thrpt   15   4921201,916 ?  410471,239  ops/s
-JavaUtilWrapperBenchmark.testRandomGetThroughput                thrpt   15   7827123,690 ?  557193,670  ops/s
-JavaUtilWrapperBenchmark.testRandomPutThroughput                thrpt   15   4832517,371 ? 1122344,647  ops/s
+JavaUtilWrapperLongLongBenchmark.testRandomAllOpsThroughput             thrpt   15    4807759.211 ±  235212.245  ops/s
+JavaUtilWrapperLongLongBenchmark.testRandomGetThroughput                thrpt   15   10518803.436 ±  343489.210  ops/s
+JavaUtilWrapperLongLongBenchmark.testRandomPutThroughput                thrpt   15    3893033.361 ± 1091839.389  ops/s
+
+JavaConcurrentLongLongBenchmark.testRandomAllOpsThroughput              thrpt   15    8338702.617 ± 2339627.650  ops/s
+JavaConcurrentLongLongBenchmark.testRandomGetThroughput                 thrpt   15  115734084.910 ± 1021773.718  ops/s
+JavaConcurrentLongLongBenchmark.testRandomPutThroughput                 thrpt   15    2120419.422 ± 1616120.572  ops/s
 ```
 AverageTime per ops (less is better)
 
 ```shell
-Benchmark                                                        Mode  Cnt         Score         Error  Units
+Benchmark                                                                Mode  Cnt          Score         Error  Units
 
-FastutilWrapperBusyWaitingBenchmark.testRandomAllOpsAvgTime      avgt   15       268,790 ?      22,526  ns/op
-FastutilWrapperBusyWaitingBenchmark.testRandomGetAvgTime         avgt   15       231,552 ?      16,116  ns/op
-FastutilWrapperBusyWaitingBenchmark.testRandomPutAvgTime         avgt   10       292,246 ?      49,757  ns/op
+FastutilWrapperBusyWaitingLongLongBenchmark.testRandomAllOpsAvgTime      avgt   15        271.732 ±      23.990  ns/op
+FastutilWrapperBusyWaitingLongLongBenchmark.testRandomGetAvgTime         avgt   15        152.339 ±      20.281  ns/op
+FastutilWrapperBusyWaitingLongLongBenchmark.testRandomPutAvgTime         avgt   15        376.696 ±     104.558  ns/op
 
-FastutilWrapperDefaultBenchmark.testRandomAllOpsAvgTime          avgt   15       467,381 ?       9,790  ns/op
-FastutilWrapperDefaultBenchmark.testRandomGetAvgTime             avgt   15       237,683 ?      14,167  ns/op
-FastutilWrapperDefaultBenchmark.testRandomPutAvgTime             avgt   15       427,441 ?      25,116  ns/op
+FastutilWrapperDefaultLongLongBenchmark.testRandomAllOpsAvgTime          avgt   15        450.080 ±      74.515  ns/op
+FastutilWrapperDefaultLongLongBenchmark.testRandomGetAvgTime             avgt   15        158.247 ±      12.916  ns/op
+FastutilWrapperDefaultLongLongBenchmark.testRandomPutAvgTime             avgt   15        480.561 ±     142.326  ns/op
 
-JavaUtilWrapperBenchmark.testRandomAllOpsAvgTime                 avgt   15       781,869 ?     191,081  ns/op
-JavaUtilWrapperBenchmark.testRandomGetAvgTime                    avgt   15       470,869 ?      33,198  ns/op
-JavaUtilWrapperBenchmark.testRandomPutAvgTime                    avgt   15       964,613 ?     422,648  ns/op
+JavaUtilWrapperLongLongBenchmark.testRandomAllOpsAvgTime                 avgt   15        848.636 ±      37.767  ns/op
+JavaUtilWrapperLongLongBenchmark.testRandomGetAvgTime                    avgt   15        380.703 ±      18.391  ns/op
+JavaUtilWrapperLongLongBenchmark.testRandomPutAvgTime                    avgt   15       1083.204 ±     323.376  ns/op
+
+JavaConcurrentLongLongBenchmark.testRandomAllOpsAvgTime                  avgt   15        511.132 ±     166.567  ns/op
+JavaConcurrentLongLongBenchmark.testRandomGetAvgTime                     avgt   15         34.583 ±       0.301  ns/op
+JavaConcurrentLongLongBenchmark.testRandomPutAvgTime                     avgt   15      16723.754 ±   24368.274  ns/op
 ```
+
+#### ObjectLongMap
+
+Throughput (more is better)
+
+```shell
+Benchmark                                                                 Mode  Cnt          Score         Error  Units
+
+FastutilWrapperBusyWaitingObjectLongBenchmark.testRandomAllOpsThroughput thrpt   15   12560651.390 ± 2610919.005  ops/s
+FastutilWrapperBusyWaitingObjectLongBenchmark.testRandomGetThroughput    thrpt   15   26366394.724 ± 2433787.656  ops/s
+FastutilWrapperBusyWaitingObjectLongBenchmark.testRandomPutThroughput    thrpt   15    5633586.398 ± 2592634.909  ops/s
+
+FastutilWrapperDefaultObjectLongBenchmark.testRandomAllOpsThroughput     thrpt   15    8107579.700 ± 1356806.057  ops/s
+FastutilWrapperDefaultObjectLongBenchmark.testRandomGetThroughput        thrpt   15   22899340.190 ± 2745129.956  ops/s
+FastutilWrapperDefaultObjectLongBenchmark.testRandomPutThroughput        thrpt   15    5115575.519 ± 1510259.367  ops/s
+
+JavaUtilWrapperObjectLongBenchmark.testRandomAllOpsThroughput            thrpt   15    5146475.879 ±  876528.313  ops/s
+JavaUtilWrapperObjectLongBenchmark.testRandomGetThroughput               thrpt   15   15354340.310 ±  413172.576  ops/s
+JavaUtilWrapperObjectLongBenchmark.testRandomPutThroughput               thrpt   15    3349970.826 ±  466818.411  ops/s
+
+JavaConcurrentObjectLongBenchmark.testRandomAllOpsThroughput             thrpt   15    9802597.556 ±  845121.891  ops/s
+JavaConcurrentObjectLongBenchmark.testRandomGetThroughput                thrpt   15  144324735.489 ± 3072330.160  ops/s
+JavaConcurrentObjectLongBenchmark.testRandomPutThroughput                thrpt   15    2717410.407 ± 1995361.332  ops/s
+```
+AverageTime per ops (less is better)
+
+```shell
+Benchmark                                                                 Mode  Cnt          Score         Error  Units
+
+FastutilWrapperBusyWaitingObjectLongBenchmark.testRandomAllOpsAvgTime     avgt   15        339.809 ±      80.612  ns/op
+FastutilWrapperBusyWaitingObjectLongBenchmark.testRandomGetAvgTime        avgt   15        193.411 ±      26.775  ns/op
+FastutilWrapperBusyWaitingObjectLongBenchmark.testRandomPutAvgTime        avgt   15        951.206 ±     617.310  ns/op
+
+FastutilWrapperDefaultObjectLongBenchmark.testRandomAllOpsAvgTime         avgt   15        496.373 ±      70.106  ns/op
+FastutilWrapperDefaultObjectLongBenchmark.testRandomGetAvgTime            avgt   15        179.065 ±      18.389  ns/op
+FastutilWrapperDefaultObjectLongBenchmark.testRandomPutAvgTime            avgt   15        831.579 ±     268.410  ns/op
+
+JavaUtilWrapperObjectLongBenchmark.testRandomAllOpsAvgTime                avgt   15        785.415 ±     153.079  ns/op
+JavaUtilWrapperObjectLongBenchmark.testRandomGetAvgTime                   avgt   15        251.149 ±      10.494  ns/op
+JavaUtilWrapperObjectLongBenchmark.testRandomPutAvgTime                   avgt   15       1211.072 ±     152.786  ns/op
+
+JavaConcurrentObjectLongBenchmark.testRandomAllOpsAvgTime                 avgt   15        418.897 ±      35.770  ns/op
+JavaConcurrentObjectLongBenchmark.testRandomGetAvgTime                    avgt   15         27.664 ±       0.125  ns/op
+JavaConcurrentObjectLongBenchmark.testRandomPutAvgTime                    avgt   15       7039.788 ±   10679.090  ns/op
+```
+
+#### Info
 
 The machine
 ```shell
-MacBook Pro (15-inch, 2019)
-Processor 2,6 GHz 6-Core Intel Core i7
-Memory 16 GB 2400 MHz DDR4
+OS Kubuntu 24.10
+Processor 3,4 GHz 16-Core AMD Ryzen 9 5950X
+Memory 64 GB 3600 MHz DDR4
 ```
 
 ## Maintainers

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ mavenPublishing {
     }
 }
 
-sourceCompatibility = 11
-targetCompatibility = 11
+sourceCompatibility = 14
+targetCompatibility = 14
 
 sourceSets {
     jmh {

--- a/src/jmh/java/com/trivago/kangaroo/long2long/AbstractLongLongBenchHelper.java
+++ b/src/jmh/java/com/trivago/kangaroo/long2long/AbstractLongLongBenchHelper.java
@@ -1,31 +1,25 @@
-package com.trivago.kangaroo;
+package com.trivago.kangaroo.long2long;
 
 import com.trivago.fastutilconcurrentwrapper.ConcurrentLongLongMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
 import com.trivago.fastutilconcurrentwrapper.LongLongMap;
+import com.trivago.kangaroo.AbstractCommonBenchHelper;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-public abstract class AbstractBenchHelper extends AbstractCommonBenchHelper {
+public abstract class AbstractLongLongBenchHelper extends AbstractCommonBenchHelper {
 
     protected static final int NUM_VALUES = 1_000_000;
 
     protected LongLongMap map;
 
-    public void initAndLoadData(ConcurrentLongLongMapBuilder.MapMode mode) {
-        if (mode.equals(ConcurrentLongLongMapBuilder.MapMode.BUSY_WAITING)) {
-            map = ConcurrentLongLongMapBuilder.newBuilder()
-                    .withBuckets(16)
-                    .withInitialCapacity(NUM_VALUES)
-                    .withMode(ConcurrentLongLongMapBuilder.MapMode.BUSY_WAITING)
-                    .withLoadFactor(0.8f)
-                    .build();
-        } else {
-            map = ConcurrentLongLongMapBuilder.newBuilder()
-                    .withBuckets(16)
-                    .withInitialCapacity(NUM_VALUES)
-                    .withLoadFactor(0.8f)
-                    .build();
-        }
+    public void initAndLoadData(ConcurrentMapBuilder.MapMode mode) {
+        map = ConcurrentLongLongMapBuilder.newBuilder()
+                .withBuckets(16)
+                .withInitialCapacity(NUM_VALUES)
+                .withMode(mode)
+                .withLoadFactor(0.8f)
+                .build();
 
         for (int i = 0; i < NUM_VALUES; i++) {
             long key = ThreadLocalRandom.current().nextLong();

--- a/src/jmh/java/com/trivago/kangaroo/long2long/AbstractLongLongBenchHelper.java
+++ b/src/jmh/java/com/trivago/kangaroo/long2long/AbstractLongLongBenchHelper.java
@@ -1,8 +1,8 @@
 package com.trivago.kangaroo.long2long;
 
-import com.trivago.fastutilconcurrentwrapper.ConcurrentLongLongMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.ConcurrentLongLongMapBuilder;
 import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongLongMap;
 import com.trivago.kangaroo.AbstractCommonBenchHelper;
 
 import java.util.concurrent.ThreadLocalRandom;

--- a/src/jmh/java/com/trivago/kangaroo/long2long/FastutilWrapperBusyWaitingLongLongBenchmark.java
+++ b/src/jmh/java/com/trivago/kangaroo/long2long/FastutilWrapperBusyWaitingLongLongBenchmark.java
@@ -1,6 +1,6 @@
-package com.trivago.kangaroo;
+package com.trivago.kangaroo.long2long;
 
-import com.trivago.fastutilconcurrentwrapper.ConcurrentLongLongMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
@@ -11,10 +11,10 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 3, time = 2)
-public class FastutilWrapperBusyWaitingBenchmark extends AbstractBenchHelper {
+public class FastutilWrapperBusyWaitingLongLongBenchmark extends AbstractLongLongBenchHelper {
 
     @Setup(Level.Trial)
     public void loadData() {
-        super.initAndLoadData(ConcurrentLongLongMapBuilder.MapMode.BUSY_WAITING);
+        super.initAndLoadData(ConcurrentMapBuilder.MapMode.BUSY_WAITING);
     }
 }

--- a/src/jmh/java/com/trivago/kangaroo/long2long/FastutilWrapperDefaultLongLongBenchmark.java
+++ b/src/jmh/java/com/trivago/kangaroo/long2long/FastutilWrapperDefaultLongLongBenchmark.java
@@ -1,6 +1,6 @@
-package com.trivago.kangaroo;
+package com.trivago.kangaroo.long2long;
 
-import com.trivago.fastutilconcurrentwrapper.ConcurrentLongLongMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Scope;
@@ -11,10 +11,10 @@ import org.openjdk.jmh.annotations.Warmup;
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 3, time = 2)
-public class FastutilWrapperDefaultBenchmark extends AbstractBenchHelper {
+public class FastutilWrapperDefaultLongLongBenchmark extends AbstractLongLongBenchHelper {
 
     @Setup(Level.Trial)
     public void loadData() {
-        super.initAndLoadData(ConcurrentLongLongMapBuilder.MapMode.BLOCKING);
+        super.initAndLoadData(ConcurrentMapBuilder.MapMode.BLOCKING);
     }
 }

--- a/src/jmh/java/com/trivago/kangaroo/long2long/JavaConcurrentLongLongBenchmark.java
+++ b/src/jmh/java/com/trivago/kangaroo/long2long/JavaConcurrentLongLongBenchmark.java
@@ -1,33 +1,27 @@
-package com.trivago.kangaroo;
+package com.trivago.kangaroo.long2long;
 
-import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
-import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.Setup;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Warmup;
+import com.trivago.kangaroo.AbstractCommonBenchHelper;
+import org.openjdk.jmh.annotations.*;
 
-import java.util.Collections;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 
 @State(Scope.Benchmark)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 3, time = 2)
-public class JavaUtilWrapperBenchmark extends AbstractCommonBenchHelper {
+public class JavaConcurrentLongLongBenchmark extends AbstractCommonBenchHelper {
 
     Map<Long, Long> map;
 
     @Setup(Level.Trial)
     public void loadData() {
-        Long2LongOpenHashMap m = new Long2LongOpenHashMap(AbstractBenchHelper.NUM_VALUES, 0.8f);
-        for (int i = 0; i < AbstractBenchHelper.NUM_VALUES; i++) {
+        map = new ConcurrentHashMap<>(AbstractLongLongBenchHelper.NUM_VALUES, 0.8f);
+        for (int i = 0; i < AbstractLongLongBenchHelper.NUM_VALUES; i++) {
             long key = ThreadLocalRandom.current().nextLong();
             long value = ThreadLocalRandom.current().nextLong();
-            m.put(key, value);
+            map.put(key, value);
         }
-        map = Collections.synchronizedMap(m);
     }
 
     public void testGet() {

--- a/src/jmh/java/com/trivago/kangaroo/long2long/JavaUtilWrapperLongLongBenchmark.java
+++ b/src/jmh/java/com/trivago/kangaroo/long2long/JavaUtilWrapperLongLongBenchmark.java
@@ -1,0 +1,61 @@
+package com.trivago.kangaroo.long2long;
+
+import com.trivago.kangaroo.AbstractCommonBenchHelper;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 2)
+public class JavaUtilWrapperLongLongBenchmark extends AbstractCommonBenchHelper {
+
+    Map<Long, Long> map;
+
+    @Setup(Level.Trial)
+    public void loadData() {
+        Long2LongOpenHashMap m = new Long2LongOpenHashMap(AbstractLongLongBenchHelper.NUM_VALUES, 0.8f);
+        for (int i = 0; i < AbstractLongLongBenchHelper.NUM_VALUES; i++) {
+            long key = ThreadLocalRandom.current().nextLong();
+            long value = ThreadLocalRandom.current().nextLong();
+            m.put(key, value);
+        }
+        map = Collections.synchronizedMap(m);
+    }
+
+    public void testGet() {
+        long key = ThreadLocalRandom.current().nextLong();
+        map.get(key);
+    }
+
+    public void testPut() {
+        long key = ThreadLocalRandom.current().nextLong();
+        long value = ThreadLocalRandom.current().nextLong();
+        map.put(key, value);
+    }
+
+    public void testAllOps() {
+        int op = ThreadLocalRandom.current().nextInt(3);
+        long key = ThreadLocalRandom.current().nextLong();
+        switch (op) {
+            case 1:
+                long value = ThreadLocalRandom.current().nextLong();
+                map.put(key, value);
+                break;
+            case 2:
+                map.remove(key);
+                break;
+            default:
+                map.get(key);
+                break;
+        }
+    }
+}

--- a/src/jmh/java/com/trivago/kangaroo/object2long/AbstractObjectLongBenchHelper.java
+++ b/src/jmh/java/com/trivago/kangaroo/object2long/AbstractObjectLongBenchHelper.java
@@ -1,0 +1,59 @@
+package com.trivago.kangaroo.object2long;
+
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ConcurrentObjectLongMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectLongMap;
+import com.trivago.kangaroo.AbstractCommonBenchHelper;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public abstract class AbstractObjectLongBenchHelper extends AbstractCommonBenchHelper {
+
+    protected static final int NUM_VALUES = 1_000_000;
+
+    protected ObjectLongMap<TestObjectKey> map;
+
+    public void initAndLoadData(ConcurrentMapBuilder.MapMode mode) {
+        map = ConcurrentObjectLongMapBuilder.<TestObjectKey>newBuilder()
+                .withBuckets(16)
+                .withInitialCapacity(NUM_VALUES)
+                .withMode(mode)
+                .withLoadFactor(0.8f)
+                .build();
+
+        for (int i = 0; i < NUM_VALUES; i++) {
+            TestObjectKey key = new TestObjectKey();
+            long value = ThreadLocalRandom.current().nextLong();
+            map.put(key, value);
+        }
+    }
+
+    public void testGet() {
+        TestObjectKey key = new TestObjectKey();
+        map.get(key);
+    }
+
+    public void testPut() {
+        TestObjectKey key = new TestObjectKey();
+        long value = ThreadLocalRandom.current().nextLong();
+        map.put(key, value);
+    }
+
+    public void testAllOps() {
+        int op = ThreadLocalRandom.current().nextInt(3);
+        TestObjectKey key = new TestObjectKey();
+        switch (op) {
+            case 1:
+                long value = ThreadLocalRandom.current().nextLong();
+                map.put(key, value);
+                break;
+            case 2:
+                map.remove(key);
+                break;
+            default:
+                map.get(key);
+                break;
+        }
+    }
+
+}

--- a/src/jmh/java/com/trivago/kangaroo/object2long/FastutilWrapperBusyWaitingObjectLongBenchmark.java
+++ b/src/jmh/java/com/trivago/kangaroo/object2long/FastutilWrapperBusyWaitingObjectLongBenchmark.java
@@ -1,0 +1,15 @@
+package com.trivago.kangaroo.object2long;
+
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import org.openjdk.jmh.annotations.*;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 2)
+public class FastutilWrapperBusyWaitingObjectLongBenchmark extends AbstractObjectLongBenchHelper {
+
+    @Setup(Level.Trial)
+    public void loadData() {
+        super.initAndLoadData(ConcurrentMapBuilder.MapMode.BUSY_WAITING);
+    }
+}

--- a/src/jmh/java/com/trivago/kangaroo/object2long/FastutilWrapperDefaultObjectLongBenchmark.java
+++ b/src/jmh/java/com/trivago/kangaroo/object2long/FastutilWrapperDefaultObjectLongBenchmark.java
@@ -1,0 +1,15 @@
+package com.trivago.kangaroo.object2long;
+
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import org.openjdk.jmh.annotations.*;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 2)
+public class FastutilWrapperDefaultObjectLongBenchmark extends AbstractObjectLongBenchHelper {
+
+    @Setup(Level.Trial)
+    public void loadData() {
+        super.initAndLoadData(ConcurrentMapBuilder.MapMode.BLOCKING);
+    }
+}

--- a/src/jmh/java/com/trivago/kangaroo/object2long/JavaConcurrentObjectLongBenchmark.java
+++ b/src/jmh/java/com/trivago/kangaroo/object2long/JavaConcurrentObjectLongBenchmark.java
@@ -1,0 +1,53 @@
+package com.trivago.kangaroo.object2long;
+
+import com.trivago.kangaroo.AbstractCommonBenchHelper;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 2)
+public class JavaConcurrentObjectLongBenchmark extends AbstractCommonBenchHelper {
+
+    Map<TestObjectKey, Long> map;
+
+    @Setup(Level.Trial)
+    public void loadData() {
+        map = new ConcurrentHashMap<>(AbstractObjectLongBenchHelper.NUM_VALUES, 0.8f);
+        for (int i = 0; i < AbstractObjectLongBenchHelper.NUM_VALUES; i++) {
+            TestObjectKey key = new TestObjectKey();
+            long value = ThreadLocalRandom.current().nextLong();
+            map.put(key, value);
+        }
+    }
+
+    public void testGet() {
+        map.get(new TestObjectKey());
+    }
+
+    public void testPut() {
+        TestObjectKey key = new TestObjectKey();
+        long value = ThreadLocalRandom.current().nextLong();
+        map.put(key, value);
+    }
+
+    public void testAllOps() {
+        int op = ThreadLocalRandom.current().nextInt(3);
+        TestObjectKey key = new TestObjectKey();
+        switch (op) {
+            case 1:
+                long value = ThreadLocalRandom.current().nextLong();
+                map.put(key, value);
+                break;
+            case 2:
+                map.remove(key);
+                break;
+            default:
+                map.get(key);
+                break;
+        }
+    }
+}

--- a/src/jmh/java/com/trivago/kangaroo/object2long/JavaUtilWrapperObjectLongBenchmark.java
+++ b/src/jmh/java/com/trivago/kangaroo/object2long/JavaUtilWrapperObjectLongBenchmark.java
@@ -1,0 +1,55 @@
+package com.trivago.kangaroo.object2long;
+
+import com.trivago.kangaroo.AbstractCommonBenchHelper;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
+
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 1)
+@Measurement(iterations = 3, time = 2)
+public class JavaUtilWrapperObjectLongBenchmark extends AbstractCommonBenchHelper {
+
+    Map<TestObjectKey, Long> map;
+
+    @Setup(Level.Trial)
+    public void loadData() {
+        Object2LongOpenHashMap<TestObjectKey> m = new Object2LongOpenHashMap<>(AbstractObjectLongBenchHelper.NUM_VALUES, 0.8f);
+        for (int i = 0; i < AbstractObjectLongBenchHelper.NUM_VALUES; i++) {
+            TestObjectKey key = new TestObjectKey();
+            long value = ThreadLocalRandom.current().nextLong();
+            m.put(key, value);
+        }
+        map = Collections.synchronizedMap(m);
+    }
+
+    public void testGet() {
+        map.get(new TestObjectKey());
+    }
+
+    public void testPut() {
+        TestObjectKey key = new TestObjectKey();
+        long value = ThreadLocalRandom.current().nextLong();
+        map.put(key, value);
+    }
+
+    public void testAllOps() {
+        int op = ThreadLocalRandom.current().nextInt(3);
+        TestObjectKey key = new TestObjectKey();
+        switch (op) {
+            case 1:
+                long value = ThreadLocalRandom.current().nextLong();
+                map.put(key, value);
+                break;
+            case 2:
+                map.remove(key);
+                break;
+            default:
+                map.get(key);
+                break;
+        }
+    }
+}

--- a/src/jmh/java/com/trivago/kangaroo/object2long/TestObjectKey.java
+++ b/src/jmh/java/com/trivago/kangaroo/object2long/TestObjectKey.java
@@ -1,0 +1,13 @@
+package com.trivago.kangaroo.object2long;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class TestObjectKey {
+
+    private final int id = ThreadLocalRandom.current().nextInt();
+
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(id);
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentIntFloatMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentIntFloatMapBuilder.java
@@ -3,13 +3,10 @@ package com.trivago.fastutilconcurrentwrapper;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingIntFloatMap;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentIntFloatMap;
 
-public final class ConcurrentIntFloatMapBuilder {
+public final class ConcurrentIntFloatMapBuilder
+        extends ConcurrentMapBuilder<ConcurrentIntFloatMapBuilder, IntFloatMap> {
 
-    private MapMode mapMode = MapMode.BUSY_WAITING;
-    private int buckets = 8;
     private float defaultValue = 0.0f;
-    private int initialCapacity = 100_000;
-    private float loadFactor = 0.8f;
 
     private ConcurrentIntFloatMapBuilder() {
     }
@@ -18,57 +15,26 @@ public final class ConcurrentIntFloatMapBuilder {
         return new ConcurrentIntFloatMapBuilder();
     }
 
-    public ConcurrentIntFloatMapBuilder withBuckets(int buckets) {
-        this.buckets = buckets;
-        return this;
-    }
-
     public ConcurrentIntFloatMapBuilder withDefaultValue(float defaultValue) {
         this.defaultValue = defaultValue;
         return this;
     }
 
-    public ConcurrentIntFloatMapBuilder withInitialCapacity(int initialCapacity) {
-        this.initialCapacity = initialCapacity;
-        return this;
-    }
-
-    public ConcurrentIntFloatMapBuilder withLoadFactor(float loadFactor) {
-        this.loadFactor = loadFactor;
-        return this;
-    }
-
-    public ConcurrentIntFloatMapBuilder withMode(MapMode mapMode) {
-        this.mapMode = mapMode;
-        return this;
-    }
-
+    @Override
     public IntFloatMap build() {
-        return mapMode.createMap(this);
-    }
-
-    public enum MapMode {
-        BUSY_WAITING {
-            @Override
-            IntFloatMap createMap(ConcurrentIntFloatMapBuilder builder) {
-                return new ConcurrentBusyWaitingIntFloatMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
-        },
-        BLOCKING {
-            @Override
-            IntFloatMap createMap(ConcurrentIntFloatMapBuilder builder) {
-                return new ConcurrentIntFloatMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
+        return switch (mapMode) {
+            case BUSY_WAITING -> new ConcurrentBusyWaitingIntFloatMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+            case BLOCKING -> new ConcurrentIntFloatMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
         };
-
-        abstract IntFloatMap createMap(ConcurrentIntFloatMapBuilder builder);
     }
 }

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentIntIntMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentIntIntMapBuilder.java
@@ -3,13 +3,9 @@ package com.trivago.fastutilconcurrentwrapper;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingIntIntMap;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentIntIntMap;
 
-public final class ConcurrentIntIntMapBuilder {
+public final class ConcurrentIntIntMapBuilder extends ConcurrentMapBuilder<ConcurrentIntIntMapBuilder, IntIntMap> {
 
-    private MapMode mapMode = MapMode.BLOCKING;
-    private int buckets = 8;
     private int defaultValue = 0;
-    private int initialCapacity = 100_000;
-    private float loadFactor = 0.8f;
 
     private ConcurrentIntIntMapBuilder() {
     }
@@ -18,57 +14,26 @@ public final class ConcurrentIntIntMapBuilder {
         return new ConcurrentIntIntMapBuilder();
     }
 
-    public ConcurrentIntIntMapBuilder withBuckets(int buckets) {
-        this.buckets = buckets;
-        return this;
-    }
-
     public ConcurrentIntIntMapBuilder withDefaultValue(int defaultValue) {
         this.defaultValue = defaultValue;
         return this;
     }
 
-    public ConcurrentIntIntMapBuilder withInitialCapacity(int initialCapacity) {
-        this.initialCapacity = initialCapacity;
-        return this;
-    }
-
-    public ConcurrentIntIntMapBuilder withLoadFactor(float loadFactor) {
-        this.loadFactor = loadFactor;
-        return this;
-    }
-
-    public ConcurrentIntIntMapBuilder withMode(MapMode mapMode) {
-        this.mapMode = mapMode;
-        return this;
-    }
-
+    @Override
     public IntIntMap build() {
-        return mapMode.createMap(this);
-    }
-
-    public enum MapMode {
-        BLOCKING {
-            @Override
-            IntIntMap createMap(ConcurrentIntIntMapBuilder builder) {
-                return new ConcurrentIntIntMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
-        },
-        BUSY_WAITING {
-            @Override
-            IntIntMap createMap(ConcurrentIntIntMapBuilder builder) {
-                return new ConcurrentBusyWaitingIntIntMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
+        return switch (mapMode) {
+            case BUSY_WAITING -> new ConcurrentBusyWaitingIntIntMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+            case BLOCKING -> new ConcurrentIntIntMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
         };
-
-        abstract IntIntMap createMap(ConcurrentIntIntMapBuilder builder);
     }
 }

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongFloatMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongFloatMapBuilder.java
@@ -3,12 +3,9 @@ package com.trivago.fastutilconcurrentwrapper;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongFloatMap;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongFloatMap;
 
-public final class ConcurrentLongFloatMapBuilder {
+public final class ConcurrentLongFloatMapBuilder
+        extends ConcurrentMapBuilder<ConcurrentLongFloatMapBuilder, LongFloatMap> {
 
-    private MapMode mapMode = MapMode.BLOCKING;
-    private int buckets = 8;
-    private int initialCapacity = 100_000;
-    private float loadFactor = 0.8f;
     private float defaultValue = LongFloatMap.DEFAULT_VALUE;
 
     private ConcurrentLongFloatMapBuilder() {
@@ -18,57 +15,26 @@ public final class ConcurrentLongFloatMapBuilder {
         return new ConcurrentLongFloatMapBuilder();
     }
 
-    public ConcurrentLongFloatMapBuilder withBuckets(int buckets) {
-        this.buckets = buckets;
-        return this;
-    }
-
-    public ConcurrentLongFloatMapBuilder withInitialCapacity(int initialCapacity) {
-        this.initialCapacity = initialCapacity;
-        return this;
-    }
-
-    public ConcurrentLongFloatMapBuilder withLoadFactor(float loadFactor) {
-        this.loadFactor = loadFactor;
-        return this;
-    }
-
     public ConcurrentLongFloatMapBuilder withDefaultValue(float defaultValue) {
         this.defaultValue = defaultValue;
         return this;
     }
 
-    public ConcurrentLongFloatMapBuilder withMode(MapMode mapMode) {
-        this.mapMode = mapMode;
-        return this;
-    }
-
+    @Override
     public LongFloatMap build() {
-        return mapMode.createMap(this);
-    }
-
-    public enum MapMode {
-        BLOCKING {
-            @Override
-            LongFloatMap createMap(ConcurrentLongFloatMapBuilder builder) {
-                return new ConcurrentLongFloatMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
-        },
-        BUSY_WAITING {
-            @Override
-            LongFloatMap createMap(ConcurrentLongFloatMapBuilder builder) {
-                return new ConcurrentBusyWaitingLongFloatMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
+        return switch (mapMode) {
+            case BUSY_WAITING -> new ConcurrentBusyWaitingLongFloatMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+            case BLOCKING -> new ConcurrentLongFloatMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
         };
-
-        abstract LongFloatMap createMap(ConcurrentLongFloatMapBuilder builder);
     }
 }

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongIntMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongIntMapBuilder.java
@@ -3,39 +3,15 @@ package com.trivago.fastutilconcurrentwrapper;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongIntMap;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongIntMap;
 
-public final class ConcurrentLongIntMapBuilder {
-    private MapMode mapMode = MapMode.BLOCKING;
-    private int buckets = 8;
-    private int initialCapacity = 100_000;
-    private float loadFactor = 0.8f;
+public final class ConcurrentLongIntMapBuilder extends ConcurrentMapBuilder<ConcurrentLongIntMapBuilder, LongIntMap> {
+
     private int defaultValue = LongIntMap.DEFAULT_VALUE;
 
     private ConcurrentLongIntMapBuilder() {
-
     }
 
     public static ConcurrentLongIntMapBuilder newBuilder() {
         return new ConcurrentLongIntMapBuilder();
-    }
-
-    public ConcurrentLongIntMapBuilder withBuckets(int buckets) {
-        this.buckets = buckets;
-        return this;
-    }
-
-    public ConcurrentLongIntMapBuilder withInitialCapacity(int initialCapacity) {
-        this.initialCapacity = initialCapacity;
-        return this;
-    }
-
-    public ConcurrentLongIntMapBuilder withLoadFactor(float loadFactor) {
-        this.loadFactor = loadFactor;
-        return this;
-    }
-
-    public ConcurrentLongIntMapBuilder withMode(MapMode mapMode) {
-        this.mapMode = mapMode;
-        return this;
     }
 
     public ConcurrentLongIntMapBuilder withDefaultValue(int defaultValue) {
@@ -43,32 +19,21 @@ public final class ConcurrentLongIntMapBuilder {
         return this;
     }
 
+    @Override
     public LongIntMap build() {
-        return mapMode.createMap(this);
-    }
-
-    public enum MapMode {
-        BUSY_WAITING {
-            @Override
-            LongIntMap createMap(ConcurrentLongIntMapBuilder builder) {
-                return new ConcurrentBusyWaitingLongIntMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
-        },
-        BLOCKING {
-            @Override
-            LongIntMap createMap(ConcurrentLongIntMapBuilder builder) {
-                return new ConcurrentLongIntMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
+        return switch (mapMode) {
+            case BUSY_WAITING -> new ConcurrentBusyWaitingLongIntMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+            case BLOCKING -> new ConcurrentLongIntMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
         };
-
-        abstract LongIntMap createMap(ConcurrentLongIntMapBuilder builder);
     }
 }

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongLongMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongLongMapBuilder.java
@@ -3,39 +3,16 @@ package com.trivago.fastutilconcurrentwrapper;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongLongMap;
 import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongLongMap;
 
-public final class ConcurrentLongLongMapBuilder {
-    private MapMode mapMode = MapMode.BLOCKING;
-    private int buckets = 8;
-    private int initialCapacity = 100_000;
-    private float loadFactor = 0.8f;
+public final class ConcurrentLongLongMapBuilder
+        extends ConcurrentMapBuilder<ConcurrentLongLongMapBuilder, LongLongMap> {
+
     private long defaultValue = LongLongMap.DEFAULT_VALUE;
 
     private ConcurrentLongLongMapBuilder() {
-
     }
 
     public static ConcurrentLongLongMapBuilder newBuilder() {
         return new ConcurrentLongLongMapBuilder();
-    }
-
-    public ConcurrentLongLongMapBuilder withBuckets(int buckets) {
-        this.buckets = buckets;
-        return this;
-    }
-
-    public ConcurrentLongLongMapBuilder withInitialCapacity(int initialCapacity) {
-        this.initialCapacity = initialCapacity;
-        return this;
-    }
-
-    public ConcurrentLongLongMapBuilder withLoadFactor(float loadFactor) {
-        this.loadFactor = loadFactor;
-        return this;
-    }
-
-    public ConcurrentLongLongMapBuilder withMode(MapMode mapMode) {
-        this.mapMode = mapMode;
-        return this;
     }
 
     public ConcurrentLongLongMapBuilder withDefaultValue(long defaultValue) {
@@ -43,32 +20,21 @@ public final class ConcurrentLongLongMapBuilder {
         return this;
     }
 
+    @Override
     public LongLongMap build() {
-        return mapMode.createMap(this);
-    }
-
-    public enum MapMode {
-        BUSY_WAITING {
-            @Override
-            LongLongMap createMap(ConcurrentLongLongMapBuilder builder) {
-                return new ConcurrentBusyWaitingLongLongMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
-        },
-        BLOCKING {
-            @Override
-            LongLongMap createMap(ConcurrentLongLongMapBuilder builder) {
-                return new ConcurrentLongLongMap(
-                        builder.buckets,
-                        builder.initialCapacity,
-                        builder.loadFactor,
-                        builder.defaultValue);
-            }
+        return switch (mapMode) {
+            case BUSY_WAITING -> new ConcurrentBusyWaitingLongLongMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+            case BLOCKING -> new ConcurrentLongLongMap(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
         };
-
-        abstract LongLongMap createMap(ConcurrentLongLongMapBuilder builder);
     }
 }

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentMapBuilder.java
@@ -1,9 +1,7 @@
 package com.trivago.fastutilconcurrentwrapper;
 
 @SuppressWarnings("unchecked")
-public abstract class ConcurrentMapBuilder<
-        B extends ConcurrentMapBuilder<B, K>,
-        K extends KeyMap> {
+public abstract class ConcurrentMapBuilder<B extends ConcurrentMapBuilder<B, K>, K extends KeyMap> {
 
     protected MapMode mapMode;
     protected int buckets = 8;

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/ConcurrentMapBuilder.java
@@ -1,0 +1,42 @@
+package com.trivago.fastutilconcurrentwrapper;
+
+@SuppressWarnings("unchecked")
+public abstract class ConcurrentMapBuilder<
+        B extends ConcurrentMapBuilder<B, K>,
+        K extends KeyMap> {
+
+    protected MapMode mapMode;
+    protected int buckets = 8;
+    protected int initialCapacity = 100_000;
+    protected float loadFactor = 0.8f;
+
+    protected ConcurrentMapBuilder() {
+    }
+
+    public B withBuckets(int buckets) {
+        this.buckets = buckets;
+        return (B) this;
+    }
+
+    public B withInitialCapacity(int initialCapacity) {
+        this.initialCapacity = initialCapacity;
+        return (B) this;
+    }
+
+    public B withLoadFactor(float loadFactor) {
+        this.loadFactor = loadFactor;
+        return (B) this;
+    }
+
+    public B withMode(MapMode mapMode) {
+        this.mapMode = mapMode;
+        return (B) this;
+    }
+
+    public abstract K build();
+
+    public enum MapMode {
+        BUSY_WAITING,
+        BLOCKING
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/KeyMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/KeyMap.java
@@ -1,6 +1,6 @@
 package com.trivago.fastutilconcurrentwrapper;
 
-public interface PrimitiveKeyMap {
+public interface KeyMap {
     int size();
 
     boolean isEmpty();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/PrimitiveIntKeyMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/PrimitiveIntKeyMap.java
@@ -1,5 +1,0 @@
-package com.trivago.fastutilconcurrentwrapper;
-
-public interface PrimitiveIntKeyMap extends KeyMap {
-    boolean containsKey(int key);
-}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/PrimitiveIntKeyMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/PrimitiveIntKeyMap.java
@@ -1,5 +1,5 @@
 package com.trivago.fastutilconcurrentwrapper;
 
-public interface PrimitiveIntKeyMap extends PrimitiveKeyMap {
+public interface PrimitiveIntKeyMap extends KeyMap {
     boolean containsKey(int key);
 }

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/PrimitiveLongKeyMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/PrimitiveLongKeyMap.java
@@ -1,5 +1,5 @@
 package com.trivago.fastutilconcurrentwrapper;
 
-public interface PrimitiveLongKeyMap extends PrimitiveKeyMap {
+public interface PrimitiveLongKeyMap extends KeyMap {
     boolean containsKey(long key);
 }

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/PrimitiveLongKeyMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/PrimitiveLongKeyMap.java
@@ -1,5 +1,0 @@
-package com.trivago.fastutilconcurrentwrapper;
-
-public interface PrimitiveLongKeyMap extends KeyMap {
-    boolean containsKey(long key);
-}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectFloatMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectFloatMapBuilder.java
@@ -21,6 +21,7 @@ public final class ConcurrentObjectFloatMapBuilder<K> extends ConcurrentMapBuild
         return this;
     }
 
+    @Override
     public ObjectFloatMap<K> build() {
         return switch (mapMode) {
             case BUSY_WAITING -> new ConcurrentBusyWaitingObjectFloatMap<>(

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectFloatMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectFloatMapBuilder.java
@@ -1,0 +1,40 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys;
+
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentBusyWaitingObjectFloatMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentObjectFloatMap;
+
+public final class ConcurrentObjectFloatMapBuilder<K> extends ConcurrentMapBuilder<
+        ConcurrentObjectFloatMapBuilder<K>, ObjectFloatMap<K>> {
+
+    private float defaultValue = ObjectFloatMap.DEFAULT_VALUE;
+
+    private ConcurrentObjectFloatMapBuilder() {
+    }
+
+    public static <K> ConcurrentObjectFloatMapBuilder<K> newBuilder() {
+        return new ConcurrentObjectFloatMapBuilder<>();
+    }
+
+    public ConcurrentObjectFloatMapBuilder<K> withDefaultValue(float defaultValue) {
+        this.defaultValue = defaultValue;
+        return this;
+    }
+
+    public ObjectFloatMap<K> build() {
+        return switch (mapMode) {
+            case BUSY_WAITING -> new ConcurrentBusyWaitingObjectFloatMap<>(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+            case BLOCKING -> new ConcurrentObjectFloatMap<>(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+        };
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectIntMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectIntMapBuilder.java
@@ -1,0 +1,40 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys;
+
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentBusyWaitingObjectIntMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentObjectIntMap;
+
+public final class ConcurrentObjectIntMapBuilder<K> extends ConcurrentMapBuilder<
+        ConcurrentObjectIntMapBuilder<K>, ObjectIntMap<K>> {
+
+    private int defaultValue = ObjectIntMap.DEFAULT_VALUE;
+
+    private ConcurrentObjectIntMapBuilder() {
+    }
+
+    public static <K> ConcurrentObjectIntMapBuilder<K> newBuilder() {
+        return new ConcurrentObjectIntMapBuilder<>();
+    }
+
+    public ConcurrentObjectIntMapBuilder<K> withDefaultValue(int defaultValue) {
+        this.defaultValue = defaultValue;
+        return this;
+    }
+
+    public ObjectIntMap<K> build() {
+        return switch (mapMode) {
+            case BUSY_WAITING -> new ConcurrentBusyWaitingObjectIntMap<>(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+            case BLOCKING -> new ConcurrentObjectIntMap<>(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+        };
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectIntMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectIntMapBuilder.java
@@ -21,6 +21,7 @@ public final class ConcurrentObjectIntMapBuilder<K> extends ConcurrentMapBuilder
         return this;
     }
 
+    @Override
     public ObjectIntMap<K> build() {
         return switch (mapMode) {
             case BUSY_WAITING -> new ConcurrentBusyWaitingObjectIntMap<>(

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectLongMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectLongMapBuilder.java
@@ -21,6 +21,7 @@ public final class ConcurrentObjectLongMapBuilder<K> extends ConcurrentMapBuilde
         return this;
     }
 
+    @Override
     public ObjectLongMap<K> build() {
         return switch (mapMode) {
             case BUSY_WAITING -> new ConcurrentBusyWaitingObjectLongMap<>(

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectLongMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ConcurrentObjectLongMapBuilder.java
@@ -1,0 +1,40 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys;
+
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentBusyWaitingObjectLongMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentObjectLongMap;
+
+public final class ConcurrentObjectLongMapBuilder<K> extends ConcurrentMapBuilder<
+        ConcurrentObjectLongMapBuilder<K>, ObjectLongMap<K>> {
+
+    private long defaultValue = ObjectLongMap.DEFAULT_VALUE;
+
+    private ConcurrentObjectLongMapBuilder() {
+    }
+
+    public static <K> ConcurrentObjectLongMapBuilder<K> newBuilder() {
+        return new ConcurrentObjectLongMapBuilder<>();
+    }
+
+    public ConcurrentObjectLongMapBuilder<K> withDefaultValue(long defaultValue) {
+        this.defaultValue = defaultValue;
+        return this;
+    }
+
+    public ObjectLongMap<K> build() {
+        return switch (mapMode) {
+            case BUSY_WAITING -> new ConcurrentBusyWaitingObjectLongMap<>(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+            case BLOCKING -> new ConcurrentObjectLongMap<>(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+        };
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ObjectFloatMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ObjectFloatMap.java
@@ -1,0 +1,28 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys;
+
+import it.unimi.dsi.fastutil.objects.Object2FloatFunction;
+
+import java.util.function.BiFunction;
+
+public interface ObjectFloatMap<K> extends ObjectKeyMap<K> {
+
+    float DEFAULT_VALUE = 0F;
+
+    /**
+     * @param key
+     * @return 0 if the key is not present
+     */
+    float get(K key);
+
+    float put(K key, float value);
+
+    float getDefaultValue();
+
+    float remove(K key);
+
+    boolean remove(K key, float value);
+
+    float computeIfAbsent(K key, Object2FloatFunction<K> mappingFunction);
+
+    float computeIfPresent(K key, BiFunction<K, Float, Float> mappingFunction);
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ObjectIntMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ObjectIntMap.java
@@ -1,0 +1,28 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys;
+
+import it.unimi.dsi.fastutil.objects.Object2IntFunction;
+
+import java.util.function.BiFunction;
+
+public interface ObjectIntMap<K> extends ObjectKeyMap<K> {
+
+    int DEFAULT_VALUE = 0;
+
+    /**
+     * @param key
+     * @return 0 if the key is not present
+     */
+    int get(K key);
+
+    int put(K key, int value);
+
+    int getDefaultValue();
+
+    int remove(K key);
+
+    boolean remove(K key, int value);
+
+    int computeIfAbsent(K key, Object2IntFunction<K> mappingFunction);
+
+    int computeIfPresent(K key, BiFunction<K, Integer, Integer> mappingFunction);
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ObjectKeyMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ObjectKeyMap.java
@@ -1,0 +1,7 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys;
+
+import com.trivago.fastutilconcurrentwrapper.KeyMap;
+
+public interface ObjectKeyMap<K> extends KeyMap {
+    boolean containsKey(K key);
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ObjectLongMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/ObjectLongMap.java
@@ -1,0 +1,28 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys;
+
+import it.unimi.dsi.fastutil.objects.Object2LongFunction;
+
+import java.util.function.BiFunction;
+
+public interface ObjectLongMap<K> extends ObjectKeyMap<K> {
+
+    long DEFAULT_VALUE = 0L;
+
+    /**
+     * @param key
+     * @return 0 if the key is not present
+     */
+    long get(K key);
+
+    long put(K key, long value);
+
+    long getDefaultValue();
+
+    long remove(K key);
+
+    boolean remove(K key, long value);
+
+    long computeIfAbsent(K key, Object2LongFunction<K> mappingFunction);
+
+    long computeIfPresent(K key, BiFunction<K, Long, Long> mappingFunction);
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentBusyWaitingObjectFloatMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentBusyWaitingObjectFloatMap.java
@@ -1,0 +1,163 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectFloatMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper.PrimitiveFastutilObjectFloatWrapper;
+import it.unimi.dsi.fastutil.objects.Object2FloatFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentBusyWaitingObjectFloatMap<K> extends ObjectConcurrentMap<K> implements ObjectFloatMap<K> {
+
+    private final ObjectFloatMap<K>[] maps;
+    private final float defaultValue;
+
+    public ConcurrentBusyWaitingObjectFloatMap(int numBuckets,
+                                               int initialCapacity,
+                                               float loadFactor,
+                                               float defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new ObjectFloatMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilObjectFloatWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].containsKey(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public float get(K key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].get(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public float put(K key, float value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].put(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public float getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public float remove(K key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean remove(K key, float value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public float computeIfAbsent(K key, Object2FloatFunction<K> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfAbsent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public float computeIfPresent(K key, BiFunction<K, Float, Float> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfPresent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentBusyWaitingObjectIntMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentBusyWaitingObjectIntMap.java
@@ -1,0 +1,163 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectIntMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper.PrimitiveFastutilObjectIntWrapper;
+import it.unimi.dsi.fastutil.objects.Object2IntFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentBusyWaitingObjectIntMap<K> extends ObjectConcurrentMap<K> implements ObjectIntMap<K> {
+
+    private final ObjectIntMap<K>[] maps;
+    private final int defaultValue;
+
+    public ConcurrentBusyWaitingObjectIntMap(int numBuckets,
+                                             int initialCapacity,
+                                             float loadFactor,
+                                             int defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new ObjectIntMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilObjectIntWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].containsKey(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public int get(K key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].get(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public int put(K key, int value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].put(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public int getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public int remove(K key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean remove(K key, int value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public int computeIfAbsent(K key, Object2IntFunction<K> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfAbsent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public int computeIfPresent(K key, BiFunction<K, Integer, Integer> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfPresent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentBusyWaitingObjectLongMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentBusyWaitingObjectLongMap.java
@@ -1,0 +1,163 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectLongMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper.PrimitiveFastutilObjectLongWrapper;
+import it.unimi.dsi.fastutil.objects.Object2LongFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentBusyWaitingObjectLongMap<K> extends ObjectConcurrentMap<K> implements ObjectLongMap<K> {
+
+    private final ObjectLongMap<K>[] maps;
+    private final long defaultValue;
+
+    public ConcurrentBusyWaitingObjectLongMap(int numBuckets,
+                                              int initialCapacity,
+                                              float loadFactor,
+                                              long defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new ObjectLongMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilObjectLongWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].containsKey(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public long get(K key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].get(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public long put(K key, long value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].put(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public long getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public long remove(K key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean remove(K key, long value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public long computeIfAbsent(K key, Object2LongFunction<K> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfAbsent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public long computeIfPresent(K key, BiFunction<K, Long, Long> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfPresent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentObjectFloatMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentObjectFloatMap.java
@@ -1,0 +1,146 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectFloatMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectIntMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper.PrimitiveFastutilObjectFloatWrapper;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper.PrimitiveFastutilObjectIntWrapper;
+import it.unimi.dsi.fastutil.objects.Object2FloatFunction;
+import it.unimi.dsi.fastutil.objects.Object2IntFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentObjectFloatMap<K> extends ObjectConcurrentMap<K> implements ObjectFloatMap<K> {
+
+    private final ObjectFloatMap<K>[] maps;
+    private final float defaultValue;
+
+    public ConcurrentObjectFloatMap(int numBuckets,
+                                    int initialCapacity,
+                                    float loadFactor,
+                                    float defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new ObjectFloatMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilObjectFloatWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            return maps[bucket].containsKey(key);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    @Override
+    public float get(K l) {
+        int bucket = getBucket(l);
+
+        float result;
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            result = maps[bucket].get(l);
+        } finally {
+            readLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public float put(K key, float value) {
+        int bucket = getBucket(key);
+
+        float result;
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            result = maps[bucket].put(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public float getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public float remove(K key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public boolean remove(K key, float value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public float computeIfAbsent(K key, Object2FloatFunction<K> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfAbsent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public float computeIfPresent(K key, BiFunction<K, Float, Float> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfPresent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentObjectIntMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentObjectIntMap.java
@@ -1,0 +1,146 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectIntMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectLongMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper.PrimitiveFastutilObjectIntWrapper;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper.PrimitiveFastutilObjectLongWrapper;
+import it.unimi.dsi.fastutil.objects.Object2IntFunction;
+import it.unimi.dsi.fastutil.objects.Object2LongFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentObjectIntMap<K> extends ObjectConcurrentMap<K> implements ObjectIntMap<K> {
+
+    private final ObjectIntMap<K>[] maps;
+    private final int defaultValue;
+
+    public ConcurrentObjectIntMap(int numBuckets,
+                                  int initialCapacity,
+                                  float loadFactor,
+                                  int defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new ObjectIntMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilObjectIntWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            return maps[bucket].containsKey(key);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    @Override
+    public int get(K l) {
+        int bucket = getBucket(l);
+
+        int result;
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            result = maps[bucket].get(l);
+        } finally {
+            readLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public int put(K key, int value) {
+        int bucket = getBucket(key);
+
+        int result;
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            result = maps[bucket].put(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public int getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public int remove(K key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public boolean remove(K key, int value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public int computeIfAbsent(K key, Object2IntFunction<K> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfAbsent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public int computeIfPresent(K key, BiFunction<K, Integer, Integer> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfPresent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentObjectLongMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ConcurrentObjectLongMap.java
@@ -1,0 +1,143 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectLongMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper.PrimitiveFastutilObjectLongWrapper;
+import it.unimi.dsi.fastutil.objects.Object2LongFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentObjectLongMap<K> extends ObjectConcurrentMap<K> implements ObjectLongMap<K> {
+
+    private final ObjectLongMap<K>[] maps;
+    private final long defaultValue;
+
+    public ConcurrentObjectLongMap(int numBuckets,
+                                   int initialCapacity,
+                                   float loadFactor,
+                                   long defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new ObjectLongMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilObjectLongWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            return maps[bucket].containsKey(key);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    @Override
+    public long get(K l) {
+        int bucket = getBucket(l);
+
+        long result;
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            result = maps[bucket].get(l);
+        } finally {
+            readLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public long put(K key, long value) {
+        int bucket = getBucket(key);
+
+        long result;
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            result = maps[bucket].put(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public long getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public long remove(K key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public boolean remove(K key, long value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public long computeIfAbsent(K key, Object2LongFunction<K> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfAbsent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public long computeIfPresent(K key, BiFunction<K, Long, Long> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfPresent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ObjectConcurrentMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/map/ObjectConcurrentMap.java
@@ -1,4 +1,4 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.objectkeys.map;
 
 import com.trivago.fastutilconcurrentwrapper.KeyMap;
 
@@ -6,12 +6,12 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
-public abstract class PrimitiveConcurrentMap {
+public abstract class ObjectConcurrentMap<K> {
 
     protected final int numBuckets;
     protected final ReadWriteLock[] locks;
 
-    protected PrimitiveConcurrentMap(int numBuckets) {
+    protected ObjectConcurrentMap(int numBuckets) {
         this.numBuckets = numBuckets;
         this.locks = new ReadWriteLock[numBuckets];
         for (int i = 0; i < numBuckets; i++) {
@@ -56,14 +56,8 @@ public abstract class PrimitiveConcurrentMap {
         }
     }
 
-    protected int getBucket(long key) {
-        int hash = Long.hashCode(key);
-        return getBucketCheckMinValue(hash);
-    }
-
-    protected int getBucket(int key) {
-        int hash = Integer.hashCode(key);
-        return getBucketCheckMinValue(hash);
+    protected int getBucket(K key) {
+        return getBucketCheckMinValue(key.hashCode());
     }
 
     private int getBucketCheckMinValue(int hash) {

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/wrapper/PrimitiveFastutilObjectFloatWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/wrapper/PrimitiveFastutilObjectFloatWrapper.java
@@ -1,0 +1,71 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectFloatMap;
+import it.unimi.dsi.fastutil.objects.Object2FloatFunction;
+import it.unimi.dsi.fastutil.objects.Object2FloatOpenHashMap;
+
+import java.util.function.BiFunction;
+
+public class PrimitiveFastutilObjectFloatWrapper<K> implements ObjectFloatMap<K> {
+    private final Object2FloatOpenHashMap<K> map;
+    private final float defaultValue;
+
+    public PrimitiveFastutilObjectFloatWrapper(int initialCapacity, float loadFactor) {
+        this(initialCapacity, loadFactor, ObjectFloatMap.DEFAULT_VALUE);
+    }
+
+    public PrimitiveFastutilObjectFloatWrapper(int initialCapacity, float loadFactor, float defaultValue) {
+        this.defaultValue = defaultValue;
+        this.map = new Object2FloatOpenHashMap<>(initialCapacity, loadFactor);
+    }
+
+    @Override
+    public float get(K key) {
+        return map.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public float put(K key, float value) {
+        return map.put(key, value);
+    }
+
+    @Override
+    public float getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public float remove(K key) {
+        return map.removeFloat(key);
+    }
+
+    @Override
+    public boolean remove(K key, float value) {
+        return map.remove(key, value);
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public float computeIfAbsent(K key, Object2FloatFunction<K> mappingFunction) {
+        return map.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public float computeIfPresent(K key, BiFunction<K, Float, Float> mappingFunction) {
+        return map.computeFloatIfPresent(key, mappingFunction);
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/wrapper/PrimitiveFastutilObjectIntWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/wrapper/PrimitiveFastutilObjectIntWrapper.java
@@ -1,0 +1,71 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectIntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntFunction;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+
+import java.util.function.BiFunction;
+
+public class PrimitiveFastutilObjectIntWrapper<K> implements ObjectIntMap<K> {
+    private final Object2IntOpenHashMap<K> map;
+    private final int defaultValue;
+
+    public PrimitiveFastutilObjectIntWrapper(int initialCapacity, float loadFactor) {
+        this(initialCapacity, loadFactor, ObjectIntMap.DEFAULT_VALUE);
+    }
+
+    public PrimitiveFastutilObjectIntWrapper(int initialCapacity, float loadFactor, int defaultValue) {
+        this.defaultValue = defaultValue;
+        this.map = new Object2IntOpenHashMap<>(initialCapacity, loadFactor);
+    }
+
+    @Override
+    public int get(K key) {
+        return map.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public int put(K key, int value) {
+        return map.put(key, value);
+    }
+
+    @Override
+    public int getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public int remove(K key) {
+        return map.removeInt(key);
+    }
+
+    @Override
+    public boolean remove(K key, int value) {
+        return map.remove(key, value);
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public int computeIfAbsent(K key, Object2IntFunction<K> mappingFunction) {
+        return map.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public int computeIfPresent(K key, BiFunction<K, Integer, Integer> mappingFunction) {
+        return map.computeIntIfPresent(key, mappingFunction);
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/wrapper/PrimitiveFastutilObjectLongWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/objectkeys/wrapper/PrimitiveFastutilObjectLongWrapper.java
@@ -1,0 +1,71 @@
+package com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectLongMap;
+import it.unimi.dsi.fastutil.objects.Object2LongFunction;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+
+import java.util.function.BiFunction;
+
+public class PrimitiveFastutilObjectLongWrapper<K> implements ObjectLongMap<K> {
+    private final Object2LongOpenHashMap<K> map;
+    private final long defaultValue;
+
+    public PrimitiveFastutilObjectLongWrapper(int initialCapacity, float loadFactor) {
+        this(initialCapacity, loadFactor, ObjectLongMap.DEFAULT_VALUE);
+    }
+
+    public PrimitiveFastutilObjectLongWrapper(int initialCapacity, float loadFactor, long defaultValue) {
+        this.defaultValue = defaultValue;
+        this.map = new Object2LongOpenHashMap<>(initialCapacity, loadFactor);
+    }
+
+    @Override
+    public long get(K key) {
+        return map.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public long put(K key, long value) {
+        return map.put(key, value);
+    }
+
+    @Override
+    public long getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public long remove(K key) {
+        return map.removeLong(key);
+    }
+
+    @Override
+    public boolean remove(K key, long value) {
+        return map.remove(key, value);
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean containsKey(K key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public long computeIfAbsent(K key, Object2LongFunction<K> mappingFunction) {
+        return map.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public long computeIfPresent(K key, BiFunction<K, Long, Long> mappingFunction) {
+        return map.computeLongIfPresent(key, mappingFunction);
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentIntFloatMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentIntFloatMapBuilder.java
@@ -1,7 +1,8 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingIntFloatMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentIntFloatMap;
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingIntFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentIntFloatMap;
 
 public final class ConcurrentIntFloatMapBuilder
         extends ConcurrentMapBuilder<ConcurrentIntFloatMapBuilder, IntFloatMap> {

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentIntIntMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentIntIntMapBuilder.java
@@ -1,7 +1,8 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingIntIntMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentIntIntMap;
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingIntIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentIntIntMap;
 
 public final class ConcurrentIntIntMapBuilder extends ConcurrentMapBuilder<ConcurrentIntIntMapBuilder, IntIntMap> {
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentLongFloatMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentLongFloatMapBuilder.java
@@ -1,7 +1,8 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongFloatMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongFloatMap;
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongFloatMap;
 
 public final class ConcurrentLongFloatMapBuilder
         extends ConcurrentMapBuilder<ConcurrentLongFloatMapBuilder, LongFloatMap> {

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentLongIntMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentLongIntMapBuilder.java
@@ -1,7 +1,8 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongIntMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongIntMap;
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongIntMap;
 
 public final class ConcurrentLongIntMapBuilder extends ConcurrentMapBuilder<ConcurrentLongIntMapBuilder, LongIntMap> {
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentLongLongMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentLongLongMapBuilder.java
@@ -1,7 +1,8 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongLongMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongLongMap;
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongLongMap;
 
 public final class ConcurrentLongLongMapBuilder
         extends ConcurrentMapBuilder<ConcurrentLongLongMapBuilder, LongLongMap> {

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentLongObjectMapBuilder.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/ConcurrentLongObjectMapBuilder.java
@@ -1,0 +1,41 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
+
+import com.trivago.fastutilconcurrentwrapper.ConcurrentMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongObjectMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongObjectMap;
+
+public final class ConcurrentLongObjectMapBuilder<V>
+        extends ConcurrentMapBuilder<ConcurrentLongObjectMapBuilder<V>, LongObjectMap<V>> {
+
+    private V defaultValue = null;
+
+    private ConcurrentLongObjectMapBuilder() {
+    }
+
+    public static <V> ConcurrentLongObjectMapBuilder<V> newBuilder() {
+        return new ConcurrentLongObjectMapBuilder<>();
+    }
+
+    public ConcurrentLongObjectMapBuilder<V> withDefaultValue(V defaultValue) {
+        this.defaultValue = defaultValue;
+        return this;
+    }
+
+    @Override
+    public LongObjectMap<V> build() {
+        return switch (mapMode) {
+            case BUSY_WAITING -> new ConcurrentBusyWaitingLongObjectMap<>(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+            case BLOCKING -> new ConcurrentLongObjectMap<>(
+                    this.buckets,
+                    this.initialCapacity,
+                    this.loadFactor,
+                    this.defaultValue
+            );
+        };
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/IntFloatMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/IntFloatMap.java
@@ -1,4 +1,4 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
 import it.unimi.dsi.fastutil.ints.Int2FloatFunction;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/IntIntMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/IntIntMap.java
@@ -1,4 +1,4 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/IntObjectMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/IntObjectMap.java
@@ -1,0 +1,22 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
+
+import java.util.function.BiFunction;
+
+public interface IntObjectMap<V> extends PrimitiveIntKeyMap {
+
+    V get(int key);
+
+    V put(int key, V value);
+
+    V getDefaultValue();
+
+    V remove(int key);
+
+    boolean remove(int key, V value);
+
+    V computeIfAbsent(int key, Int2ObjectFunction<V> mappingFunction);
+
+    V computeIfPresent(int key, BiFunction<Integer, V, V> mappingFunction);
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/LongFloatMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/LongFloatMap.java
@@ -1,4 +1,4 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
 import it.unimi.dsi.fastutil.longs.Long2FloatFunction;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/LongIntMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/LongIntMap.java
@@ -1,4 +1,4 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
 import it.unimi.dsi.fastutil.longs.Long2IntFunction;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/LongLongMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/LongLongMap.java
@@ -1,4 +1,4 @@
-package com.trivago.fastutilconcurrentwrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
 
 import it.unimi.dsi.fastutil.longs.Long2LongFunction;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/LongObjectMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/LongObjectMap.java
@@ -1,0 +1,22 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectFunction;
+
+import java.util.function.BiFunction;
+
+public interface LongObjectMap<V> extends PrimitiveLongKeyMap {
+
+    V get(long key);
+
+    V put(long key, V value);
+
+    V getDefaultValue();
+
+    V remove(long key);
+
+    boolean remove(long key, V value);
+
+    V computeIfAbsent(long key, Long2ObjectFunction<V> mappingFunction);
+
+    V computeIfPresent(long key, BiFunction<Long, V, V> mappingFunction);
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/PrimitiveIntKeyMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/PrimitiveIntKeyMap.java
@@ -1,0 +1,7 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
+
+import com.trivago.fastutilconcurrentwrapper.KeyMap;
+
+public interface PrimitiveIntKeyMap extends KeyMap {
+    boolean containsKey(int key);
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/PrimitiveLongKeyMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/PrimitiveLongKeyMap.java
@@ -1,0 +1,7 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys;
+
+import com.trivago.fastutilconcurrentwrapper.KeyMap;
+
+public interface PrimitiveLongKeyMap extends KeyMap {
+    boolean containsKey(long key);
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingIntFloatMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingIntFloatMap.java
@@ -1,31 +1,28 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.LongIntMap;
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilLongIntWrapper;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilLongLongWrapper;
-import it.unimi.dsi.fastutil.longs.Long2IntFunction;
-import it.unimi.dsi.fastutil.longs.Long2LongFunction;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilIntFloatWrapper;
+import it.unimi.dsi.fastutil.ints.Int2FloatFunction;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 
-public class ConcurrentBusyWaitingLongIntMap extends PrimitiveConcurrentMap implements LongIntMap {
+public class ConcurrentBusyWaitingIntFloatMap extends PrimitiveConcurrentMap implements IntFloatMap {
 
-    private final LongIntMap[] maps;
-    private final int defaultValue;
+    private final IntFloatMap[] maps;
+    private final float defaultValue;
 
-    public ConcurrentBusyWaitingLongIntMap(int numBuckets,
-                                           int initialCapacity,
-                                           float loadFactor,
-                                           int defaultValue) {
+    public ConcurrentBusyWaitingIntFloatMap(int numBuckets,
+                                            int initialCapacity,
+                                            float loadFactor,
+                                            float defaultValue) {
         super(numBuckets);
 
-        this.maps = new LongIntMap[numBuckets];
+        this.maps = new IntFloatMap[numBuckets];
         this.defaultValue = defaultValue;
 
         for (int i = 0; i < numBuckets; i++) {
-            maps[i] = new PrimitiveFastutilLongIntWrapper(initialCapacity, loadFactor, defaultValue);
+            maps[i] = new PrimitiveFastutilIntFloatWrapper(initialCapacity, loadFactor, defaultValue);
         }
     }
 
@@ -40,7 +37,7 @@ public class ConcurrentBusyWaitingLongIntMap extends PrimitiveConcurrentMap impl
     }
 
     @Override
-    public boolean containsKey(long key) {
+    public boolean containsKey(int key) {
         int bucket = getBucket(key);
 
         Lock readLock = locks[bucket].readLock();
@@ -57,7 +54,7 @@ public class ConcurrentBusyWaitingLongIntMap extends PrimitiveConcurrentMap impl
     }
 
     @Override
-    public int get(long key) {
+    public float get(int key) {
         int bucket = getBucket(key);
 
         Lock readLock = locks[bucket].readLock();
@@ -74,7 +71,7 @@ public class ConcurrentBusyWaitingLongIntMap extends PrimitiveConcurrentMap impl
     }
 
     @Override
-    public int put(long key, int value) {
+    public float put(int key, float value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -91,12 +88,12 @@ public class ConcurrentBusyWaitingLongIntMap extends PrimitiveConcurrentMap impl
     }
 
     @Override
-    public int getDefaultValue() {
+    public float getDefaultValue() {
         return defaultValue;
     }
 
     @Override
-    public int remove(long key) {
+    public float remove(int key) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -113,7 +110,7 @@ public class ConcurrentBusyWaitingLongIntMap extends PrimitiveConcurrentMap impl
     }
 
     @Override
-    public boolean remove(long key, int value) {
+    public boolean remove(int key, float value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -130,7 +127,7 @@ public class ConcurrentBusyWaitingLongIntMap extends PrimitiveConcurrentMap impl
     }
 
     @Override
-    public int computeIfAbsent(long key, Long2IntFunction mappingFunction) {
+    public float computeIfAbsent(int key, Int2FloatFunction mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -147,7 +144,7 @@ public class ConcurrentBusyWaitingLongIntMap extends PrimitiveConcurrentMap impl
     }
 
     @Override
-    public int computeIfPresent(long key, BiFunction<Long, Integer, Integer> mappingFunction) {
+    public float computeIfPresent(int key, BiFunction<Integer, Float, Float> mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingIntIntMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingIntIntMap.java
@@ -1,28 +1,28 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.IntFloatMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilIntFloatWrapper;
-import it.unimi.dsi.fastutil.ints.Int2FloatFunction;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilIntIntWrapper;
+import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 
-public class ConcurrentBusyWaitingIntFloatMap extends PrimitiveConcurrentMap implements IntFloatMap {
+public class ConcurrentBusyWaitingIntIntMap extends PrimitiveConcurrentMap implements IntIntMap {
 
-    private final IntFloatMap[] maps;
-    private final float defaultValue;
+    private final IntIntMap[] maps;
+    private final int defaultValue;
 
-    public ConcurrentBusyWaitingIntFloatMap(int numBuckets,
-                                            int initialCapacity,
-                                            float loadFactor,
-                                            float defaultValue) {
+    public ConcurrentBusyWaitingIntIntMap(int numBuckets,
+                                          int initialCapacity,
+                                          float loadFactor,
+                                          int defaultValue) {
         super(numBuckets);
 
-        this.maps = new IntFloatMap[numBuckets];
+        this.maps = new IntIntMap[numBuckets];
         this.defaultValue = defaultValue;
 
         for (int i = 0; i < numBuckets; i++) {
-            maps[i] = new PrimitiveFastutilIntFloatWrapper(initialCapacity, loadFactor, defaultValue);
+            maps[i] = new PrimitiveFastutilIntIntWrapper(initialCapacity, loadFactor, defaultValue);
         }
     }
 
@@ -54,7 +54,7 @@ public class ConcurrentBusyWaitingIntFloatMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public float get(int key) {
+    public int get(int key) {
         int bucket = getBucket(key);
 
         Lock readLock = locks[bucket].readLock();
@@ -71,7 +71,7 @@ public class ConcurrentBusyWaitingIntFloatMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public float put(int key, float value) {
+    public int put(int key, int value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -88,12 +88,12 @@ public class ConcurrentBusyWaitingIntFloatMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public float getDefaultValue() {
+    public int getDefaultValue() {
         return defaultValue;
     }
 
     @Override
-    public float remove(int key) {
+    public int remove(int key) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -110,7 +110,7 @@ public class ConcurrentBusyWaitingIntFloatMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public boolean remove(int key, float value) {
+    public boolean remove(int key, int value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -127,7 +127,7 @@ public class ConcurrentBusyWaitingIntFloatMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public float computeIfAbsent(int key, Int2FloatFunction mappingFunction) {
+    public int computeIfAbsent(int key, Int2IntFunction mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -144,7 +144,7 @@ public class ConcurrentBusyWaitingIntFloatMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public float computeIfPresent(int key, BiFunction<Integer, Float, Float> mappingFunction) {
+    public int computeIfPresent(int key, BiFunction<Integer, Integer, Integer> mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingIntObjectMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingIntObjectMap.java
@@ -1,0 +1,160 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntObjectMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilIntObjectWrapper;
+import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentBusyWaitingIntObjectMap<V> extends PrimitiveConcurrentMap implements IntObjectMap<V> {
+
+    private final IntObjectMap<V>[] maps;
+    private final V defaultValue;
+
+    public ConcurrentBusyWaitingIntObjectMap(int numBuckets, int initialCapacity, float loadFactor, V defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new IntObjectMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilIntObjectWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(int key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].containsKey(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V get(int key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].get(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V put(int key, V value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].put(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public V remove(int key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean remove(int key, V value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V computeIfAbsent(int key, Int2ObjectFunction<V> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfAbsent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V computeIfPresent(int key, BiFunction<Integer, V, V> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfPresent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingLongFloatMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingLongFloatMap.java
@@ -1,28 +1,26 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilLongLongWrapper;
-import it.unimi.dsi.fastutil.longs.Long2LongFunction;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongFloatWrapper;
+import it.unimi.dsi.fastutil.longs.Long2FloatFunction;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 
-public class ConcurrentBusyWaitingLongLongMap extends PrimitiveConcurrentMap implements LongLongMap {
+public class ConcurrentBusyWaitingLongFloatMap extends PrimitiveConcurrentMap implements LongFloatMap {
 
-    private final LongLongMap[] maps;
-    private final long defaultValue;
+    private final LongFloatMap[] maps;
+    private final float defaultValue;
 
-    public ConcurrentBusyWaitingLongLongMap(int numBuckets,
-                                            int initialCapacity,
-                                            float loadFactor,
-                                            long defaultValue) {
+    public ConcurrentBusyWaitingLongFloatMap(int numBuckets,
+                                             int initialCapacity,
+                                             float loadFactor,
+                                             float defaultValue) {
         super(numBuckets);
-
-        this.maps = new LongLongMap[numBuckets];
         this.defaultValue = defaultValue;
-
+        this.maps = new LongFloatMap[numBuckets];
         for (int i = 0; i < numBuckets; i++) {
-            maps[i] = new PrimitiveFastutilLongLongWrapper(initialCapacity, loadFactor, defaultValue);
+            maps[i] = new PrimitiveFastutilLongFloatWrapper(initialCapacity, loadFactor, defaultValue);
         }
     }
 
@@ -54,7 +52,7 @@ public class ConcurrentBusyWaitingLongLongMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public long get(long key) {
+    public float get(long key) {
         int bucket = getBucket(key);
 
         Lock readLock = locks[bucket].readLock();
@@ -71,7 +69,7 @@ public class ConcurrentBusyWaitingLongLongMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public long put(long key, long value) {
+    public float put(long key, float value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -88,12 +86,12 @@ public class ConcurrentBusyWaitingLongLongMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public long getDefaultValue() {
+    public float getDefaultValue() {
         return defaultValue;
     }
 
     @Override
-    public long remove(long key) {
+    public float remove(long key) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -110,7 +108,7 @@ public class ConcurrentBusyWaitingLongLongMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public boolean remove(long key, long value) {
+    public boolean remove(long key, float value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -127,7 +125,7 @@ public class ConcurrentBusyWaitingLongLongMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public long computeIfAbsent(long key, Long2LongFunction mappingFunction) {
+    public float computeIfAbsent(long key, Long2FloatFunction mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -144,7 +142,7 @@ public class ConcurrentBusyWaitingLongLongMap extends PrimitiveConcurrentMap imp
     }
 
     @Override
-    public long computeIfPresent(long key, BiFunction<Long, Long, Long> mappingFunction) {
+    public float computeIfPresent(int key, BiFunction<Long, Float, Float> mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingLongIntMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingLongIntMap.java
@@ -1,26 +1,28 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.LongFloatMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilLongFloatWrapper;
-import it.unimi.dsi.fastutil.longs.Long2FloatFunction;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongIntWrapper;
+import it.unimi.dsi.fastutil.longs.Long2IntFunction;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 
-public class ConcurrentBusyWaitingLongFloatMap extends PrimitiveConcurrentMap implements LongFloatMap {
+public class ConcurrentBusyWaitingLongIntMap extends PrimitiveConcurrentMap implements LongIntMap {
 
-    private final LongFloatMap[] maps;
-    private final float defaultValue;
+    private final LongIntMap[] maps;
+    private final int defaultValue;
 
-    public ConcurrentBusyWaitingLongFloatMap(int numBuckets,
-                                             int initialCapacity,
-                                             float loadFactor,
-                                             float defaultValue) {
+    public ConcurrentBusyWaitingLongIntMap(int numBuckets,
+                                           int initialCapacity,
+                                           float loadFactor,
+                                           int defaultValue) {
         super(numBuckets);
+
+        this.maps = new LongIntMap[numBuckets];
         this.defaultValue = defaultValue;
-        this.maps = new LongFloatMap[numBuckets];
+
         for (int i = 0; i < numBuckets; i++) {
-            maps[i] = new PrimitiveFastutilLongFloatWrapper(initialCapacity, loadFactor, defaultValue);
+            maps[i] = new PrimitiveFastutilLongIntWrapper(initialCapacity, loadFactor, defaultValue);
         }
     }
 
@@ -52,7 +54,7 @@ public class ConcurrentBusyWaitingLongFloatMap extends PrimitiveConcurrentMap im
     }
 
     @Override
-    public float get(long key) {
+    public int get(long key) {
         int bucket = getBucket(key);
 
         Lock readLock = locks[bucket].readLock();
@@ -69,7 +71,7 @@ public class ConcurrentBusyWaitingLongFloatMap extends PrimitiveConcurrentMap im
     }
 
     @Override
-    public float put(long key, float value) {
+    public int put(long key, int value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -86,12 +88,12 @@ public class ConcurrentBusyWaitingLongFloatMap extends PrimitiveConcurrentMap im
     }
 
     @Override
-    public float getDefaultValue() {
+    public int getDefaultValue() {
         return defaultValue;
     }
 
     @Override
-    public float remove(long key) {
+    public int remove(long key) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -108,7 +110,7 @@ public class ConcurrentBusyWaitingLongFloatMap extends PrimitiveConcurrentMap im
     }
 
     @Override
-    public boolean remove(long key, float value) {
+    public boolean remove(long key, int value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -125,7 +127,7 @@ public class ConcurrentBusyWaitingLongFloatMap extends PrimitiveConcurrentMap im
     }
 
     @Override
-    public float computeIfAbsent(long key, Long2FloatFunction mappingFunction) {
+    public int computeIfAbsent(long key, Long2IntFunction mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -142,7 +144,7 @@ public class ConcurrentBusyWaitingLongFloatMap extends PrimitiveConcurrentMap im
     }
 
     @Override
-    public float computeIfPresent(int key, BiFunction<Long, Float, Float> mappingFunction) {
+    public int computeIfPresent(long key, BiFunction<Long, Integer, Integer> mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingLongLongMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingLongLongMap.java
@@ -1,28 +1,28 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.IntIntMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilIntIntWrapper;
-import it.unimi.dsi.fastutil.ints.Int2IntFunction;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongLongWrapper;
+import it.unimi.dsi.fastutil.longs.Long2LongFunction;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 
-public class ConcurrentBusyWaitingIntIntMap extends PrimitiveConcurrentMap implements IntIntMap {
+public class ConcurrentBusyWaitingLongLongMap extends PrimitiveConcurrentMap implements LongLongMap {
 
-    private final IntIntMap[] maps;
-    private final int defaultValue;
+    private final LongLongMap[] maps;
+    private final long defaultValue;
 
-    public ConcurrentBusyWaitingIntIntMap(int numBuckets,
-                                          int initialCapacity,
-                                          float loadFactor,
-                                          int defaultValue) {
+    public ConcurrentBusyWaitingLongLongMap(int numBuckets,
+                                            int initialCapacity,
+                                            float loadFactor,
+                                            long defaultValue) {
         super(numBuckets);
 
-        this.maps = new IntIntMap[numBuckets];
+        this.maps = new LongLongMap[numBuckets];
         this.defaultValue = defaultValue;
 
         for (int i = 0; i < numBuckets; i++) {
-            maps[i] = new PrimitiveFastutilIntIntWrapper(initialCapacity, loadFactor, defaultValue);
+            maps[i] = new PrimitiveFastutilLongLongWrapper(initialCapacity, loadFactor, defaultValue);
         }
     }
 
@@ -37,7 +37,7 @@ public class ConcurrentBusyWaitingIntIntMap extends PrimitiveConcurrentMap imple
     }
 
     @Override
-    public boolean containsKey(int key) {
+    public boolean containsKey(long key) {
         int bucket = getBucket(key);
 
         Lock readLock = locks[bucket].readLock();
@@ -54,7 +54,7 @@ public class ConcurrentBusyWaitingIntIntMap extends PrimitiveConcurrentMap imple
     }
 
     @Override
-    public int get(int key) {
+    public long get(long key) {
         int bucket = getBucket(key);
 
         Lock readLock = locks[bucket].readLock();
@@ -71,7 +71,7 @@ public class ConcurrentBusyWaitingIntIntMap extends PrimitiveConcurrentMap imple
     }
 
     @Override
-    public int put(int key, int value) {
+    public long put(long key, long value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -88,12 +88,12 @@ public class ConcurrentBusyWaitingIntIntMap extends PrimitiveConcurrentMap imple
     }
 
     @Override
-    public int getDefaultValue() {
+    public long getDefaultValue() {
         return defaultValue;
     }
 
     @Override
-    public int remove(int key) {
+    public long remove(long key) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -110,7 +110,7 @@ public class ConcurrentBusyWaitingIntIntMap extends PrimitiveConcurrentMap imple
     }
 
     @Override
-    public boolean remove(int key, int value) {
+    public boolean remove(long key, long value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -127,7 +127,7 @@ public class ConcurrentBusyWaitingIntIntMap extends PrimitiveConcurrentMap imple
     }
 
     @Override
-    public int computeIfAbsent(int key, Int2IntFunction mappingFunction) {
+    public long computeIfAbsent(long key, Long2LongFunction mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -144,7 +144,7 @@ public class ConcurrentBusyWaitingIntIntMap extends PrimitiveConcurrentMap imple
     }
 
     @Override
-    public int computeIfPresent(int key, BiFunction<Integer, Integer, Integer> mappingFunction) {
+    public long computeIfPresent(long key, BiFunction<Long, Long, Long> mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingLongObjectMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentBusyWaitingLongObjectMap.java
@@ -1,0 +1,160 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongObjectMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongObjectWrapper;
+import it.unimi.dsi.fastutil.longs.Long2ObjectFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentBusyWaitingLongObjectMap<V> extends PrimitiveConcurrentMap implements LongObjectMap<V> {
+
+    private final LongObjectMap<V>[] maps;
+    private final V defaultValue;
+
+    public ConcurrentBusyWaitingLongObjectMap(int numBuckets, int initialCapacity, float loadFactor, V defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new LongObjectMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilLongObjectWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(long key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].containsKey(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V get(long key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+
+        while (true) {
+            if (readLock.tryLock()) {
+                try {
+                    return maps[bucket].get(key);
+                } finally {
+                    readLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V put(long key, V value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].put(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public V remove(long key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public boolean remove(long key, V value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].remove(key, value);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V computeIfAbsent(long key, Long2ObjectFunction<V> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfAbsent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+
+    @Override
+    public V computeIfPresent(long key, BiFunction<Long, V, V> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+
+        while (true) {
+            if (writeLock.tryLock()) {
+                try {
+                    return maps[bucket].computeIfPresent(key, mappingFunction);
+                } finally {
+                    writeLock.unlock();
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentIntFloatMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentIntFloatMap.java
@@ -1,30 +1,28 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.IntIntMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilIntIntWrapper;
-import it.unimi.dsi.fastutil.ints.Int2IntFunction;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilIntFloatWrapper;
+import it.unimi.dsi.fastutil.ints.Int2FloatFunction;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 
-public class ConcurrentIntIntMap extends PrimitiveConcurrentMap implements IntIntMap {
+public class ConcurrentIntFloatMap extends PrimitiveConcurrentMap implements IntFloatMap {
 
-    private final IntIntMap[] maps;
-    private final int defaultValue;
+    private final IntFloatMap[] maps;
+    private final float defaultValue;
 
-    public ConcurrentIntIntMap(
-            int numBuckets,
-            int initialCapacity,
-            float loadFactor,
-            int defaultValue) {
-
+    public ConcurrentIntFloatMap(int numBuckets,
+                                 int initialCapacity,
+                                 float loadFactor,
+                                 float defaultValue) {
         super(numBuckets);
 
-        this.maps = new IntIntMap[numBuckets];
+        this.maps = new IntFloatMap[numBuckets];
         this.defaultValue = defaultValue;
 
         for (int i = 0; i < numBuckets; i++) {
-            maps[i] = new PrimitiveFastutilIntIntWrapper(initialCapacity, loadFactor, defaultValue);
+            maps[i] = new PrimitiveFastutilIntFloatWrapper(initialCapacity, loadFactor, defaultValue);
         }
     }
 
@@ -52,10 +50,10 @@ public class ConcurrentIntIntMap extends PrimitiveConcurrentMap implements IntIn
     }
 
     @Override
-    public int get(int l) {
+    public float get(int l) {
         int bucket = getBucket(l);
 
-        int result;
+        float result;
 
         Lock readLock = locks[bucket].readLock();
         readLock.lock();
@@ -69,10 +67,10 @@ public class ConcurrentIntIntMap extends PrimitiveConcurrentMap implements IntIn
     }
 
     @Override
-    public int put(int key, int value) {
+    public float put(int key, float value) {
         int bucket = getBucket(key);
 
-        int result;
+        float result;
 
         Lock writeLock = locks[bucket].writeLock();
         writeLock.lock();
@@ -86,12 +84,12 @@ public class ConcurrentIntIntMap extends PrimitiveConcurrentMap implements IntIn
     }
 
     @Override
-    public int getDefaultValue() {
+    public float getDefaultValue() {
         return defaultValue;
     }
 
     @Override
-    public int remove(int key) {
+    public float remove(int key) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -104,7 +102,7 @@ public class ConcurrentIntIntMap extends PrimitiveConcurrentMap implements IntIn
     }
 
     @Override
-    public boolean remove(int key, int value) {
+    public boolean remove(int key, float value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -117,7 +115,7 @@ public class ConcurrentIntIntMap extends PrimitiveConcurrentMap implements IntIn
     }
 
     @Override
-    public int computeIfAbsent(int key, Int2IntFunction mappingFunction) {
+    public float computeIfAbsent(int key, Int2FloatFunction mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -130,7 +128,7 @@ public class ConcurrentIntIntMap extends PrimitiveConcurrentMap implements IntIn
     }
 
     @Override
-    public int computeIfPresent(int key, BiFunction<Integer, Integer, Integer> mappingFunction) {
+    public float computeIfPresent(int key, BiFunction<Integer, Float, Float> mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentIntIntMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentIntIntMap.java
@@ -1,28 +1,30 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.IntFloatMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilIntFloatWrapper;
-import it.unimi.dsi.fastutil.ints.Int2FloatFunction;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilIntIntWrapper;
+import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 
-public class ConcurrentIntFloatMap extends PrimitiveConcurrentMap implements IntFloatMap {
+public class ConcurrentIntIntMap extends PrimitiveConcurrentMap implements IntIntMap {
 
-    private final IntFloatMap[] maps;
-    private final float defaultValue;
+    private final IntIntMap[] maps;
+    private final int defaultValue;
 
-    public ConcurrentIntFloatMap(int numBuckets,
-                                 int initialCapacity,
-                                 float loadFactor,
-                                 float defaultValue) {
+    public ConcurrentIntIntMap(
+            int numBuckets,
+            int initialCapacity,
+            float loadFactor,
+            int defaultValue) {
+
         super(numBuckets);
 
-        this.maps = new IntFloatMap[numBuckets];
+        this.maps = new IntIntMap[numBuckets];
         this.defaultValue = defaultValue;
 
         for (int i = 0; i < numBuckets; i++) {
-            maps[i] = new PrimitiveFastutilIntFloatWrapper(initialCapacity, loadFactor, defaultValue);
+            maps[i] = new PrimitiveFastutilIntIntWrapper(initialCapacity, loadFactor, defaultValue);
         }
     }
 
@@ -50,10 +52,10 @@ public class ConcurrentIntFloatMap extends PrimitiveConcurrentMap implements Int
     }
 
     @Override
-    public float get(int l) {
+    public int get(int l) {
         int bucket = getBucket(l);
 
-        float result;
+        int result;
 
         Lock readLock = locks[bucket].readLock();
         readLock.lock();
@@ -67,10 +69,10 @@ public class ConcurrentIntFloatMap extends PrimitiveConcurrentMap implements Int
     }
 
     @Override
-    public float put(int key, float value) {
+    public int put(int key, int value) {
         int bucket = getBucket(key);
 
-        float result;
+        int result;
 
         Lock writeLock = locks[bucket].writeLock();
         writeLock.lock();
@@ -84,12 +86,12 @@ public class ConcurrentIntFloatMap extends PrimitiveConcurrentMap implements Int
     }
 
     @Override
-    public float getDefaultValue() {
+    public int getDefaultValue() {
         return defaultValue;
     }
 
     @Override
-    public float remove(int key) {
+    public int remove(int key) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -102,7 +104,7 @@ public class ConcurrentIntFloatMap extends PrimitiveConcurrentMap implements Int
     }
 
     @Override
-    public boolean remove(int key, float value) {
+    public boolean remove(int key, int value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -115,7 +117,7 @@ public class ConcurrentIntFloatMap extends PrimitiveConcurrentMap implements Int
     }
 
     @Override
-    public float computeIfAbsent(int key, Int2FloatFunction mappingFunction) {
+    public int computeIfAbsent(int key, Int2IntFunction mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -128,7 +130,7 @@ public class ConcurrentIntFloatMap extends PrimitiveConcurrentMap implements Int
     }
 
     @Override
-    public float computeIfPresent(int key, BiFunction<Integer, Float, Float> mappingFunction) {
+    public int computeIfPresent(int key, BiFunction<Integer, Integer, Integer> mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentIntObjectMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentIntObjectMap.java
@@ -1,0 +1,140 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntObjectMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilIntObjectWrapper;
+import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentIntObjectMap<V> extends PrimitiveConcurrentMap implements IntObjectMap<V> {
+
+    private final IntObjectMap<V>[] maps;
+    private final V defaultValue;
+
+    public ConcurrentIntObjectMap(int numBuckets, int initialCapacity, float loadFactor, V defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new IntObjectMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilIntObjectWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(int key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            return maps[bucket].containsKey(key);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    @Override
+    public V get(int l) {
+        int bucket = getBucket(l);
+
+        V result;
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            result = maps[bucket].get(l);
+        } finally {
+            readLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public V put(int key, V value) {
+        int bucket = getBucket(key);
+
+        V result;
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            result = maps[bucket].put(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public V getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public V remove(int key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public boolean remove(int key, V value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public V computeIfAbsent(int key, Int2ObjectFunction<V> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfAbsent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public V computeIfPresent(int key, BiFunction<Integer, V, V> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfPresent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentLongFloatMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentLongFloatMap.java
@@ -1,7 +1,7 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.LongFloatMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilLongFloatWrapper;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongFloatWrapper;
 import it.unimi.dsi.fastutil.longs.Long2FloatFunction;
 
 import java.util.concurrent.locks.Lock;

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentLongIntMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentLongIntMap.java
@@ -1,28 +1,30 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilLongLongWrapper;
-import it.unimi.dsi.fastutil.longs.Long2LongFunction;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongIntWrapper;
+import it.unimi.dsi.fastutil.longs.Long2IntFunction;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 
-public class ConcurrentLongLongMap extends PrimitiveConcurrentMap implements LongLongMap {
+public class ConcurrentLongIntMap extends PrimitiveConcurrentMap implements LongIntMap {
 
-    private final LongLongMap[] maps;
-    private final long defaultValue;
+    private final LongIntMap[] maps;
+    private final int defaultValue;
 
-    public ConcurrentLongLongMap(int numBuckets,
-                                 int initialCapacity,
-                                 float loadFactor,
-                                 long defaultValue) {
+    public ConcurrentLongIntMap(
+            int numBuckets,
+            int initialCapacity,
+            float loadFactor,
+            int defaultValue) {
+
         super(numBuckets);
 
-        this.maps = new LongLongMap[numBuckets];
+        this.maps = new LongIntMap[numBuckets];
         this.defaultValue = defaultValue;
 
         for (int i = 0; i < numBuckets; i++) {
-            maps[i] = new PrimitiveFastutilLongLongWrapper(initialCapacity, loadFactor, defaultValue);
+            maps[i] = new PrimitiveFastutilLongIntWrapper(initialCapacity, loadFactor, defaultValue);
         }
     }
 
@@ -50,10 +52,10 @@ public class ConcurrentLongLongMap extends PrimitiveConcurrentMap implements Lon
     }
 
     @Override
-    public long get(long l) {
+    public int get(long l) {
         int bucket = getBucket(l);
 
-        long result;
+        int result;
 
         Lock readLock = locks[bucket].readLock();
         readLock.lock();
@@ -67,10 +69,10 @@ public class ConcurrentLongLongMap extends PrimitiveConcurrentMap implements Lon
     }
 
     @Override
-    public long put(long key, long value) {
+    public int put(long key, int value) {
         int bucket = getBucket(key);
 
-        long result;
+        int result;
 
         Lock writeLock = locks[bucket].writeLock();
         writeLock.lock();
@@ -84,12 +86,12 @@ public class ConcurrentLongLongMap extends PrimitiveConcurrentMap implements Lon
     }
 
     @Override
-    public long getDefaultValue() {
+    public int getDefaultValue() {
         return defaultValue;
     }
 
     @Override
-    public long remove(long key) {
+    public int remove(long key) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -102,7 +104,7 @@ public class ConcurrentLongLongMap extends PrimitiveConcurrentMap implements Lon
     }
 
     @Override
-    public boolean remove(long key, long value) {
+    public boolean remove(long key, int value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -115,7 +117,7 @@ public class ConcurrentLongLongMap extends PrimitiveConcurrentMap implements Lon
     }
 
     @Override
-    public long computeIfAbsent(long key, Long2LongFunction mappingFunction) {
+    public int computeIfAbsent(long key, Long2IntFunction mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -128,7 +130,7 @@ public class ConcurrentLongLongMap extends PrimitiveConcurrentMap implements Lon
     }
 
     @Override
-    public long computeIfPresent(long key, BiFunction<Long, Long, Long> mappingFunction) {
+    public int computeIfPresent(long key, BiFunction<Long, Integer, Integer> mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentLongLongMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentLongLongMap.java
@@ -1,33 +1,28 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
-import com.trivago.fastutilconcurrentwrapper.IntIntMap;
-import com.trivago.fastutilconcurrentwrapper.LongIntMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilIntIntWrapper;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilLongIntWrapper;
-import it.unimi.dsi.fastutil.ints.Int2IntFunction;
-import it.unimi.dsi.fastutil.longs.Long2IntFunction;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongLongWrapper;
+import it.unimi.dsi.fastutil.longs.Long2LongFunction;
 
 import java.util.concurrent.locks.Lock;
 import java.util.function.BiFunction;
 
-public class ConcurrentLongIntMap extends PrimitiveConcurrentMap implements LongIntMap {
+public class ConcurrentLongLongMap extends PrimitiveConcurrentMap implements LongLongMap {
 
-    private final LongIntMap[] maps;
-    private final int defaultValue;
+    private final LongLongMap[] maps;
+    private final long defaultValue;
 
-    public ConcurrentLongIntMap(
-            int numBuckets,
-            int initialCapacity,
-            float loadFactor,
-            int defaultValue) {
-
+    public ConcurrentLongLongMap(int numBuckets,
+                                 int initialCapacity,
+                                 float loadFactor,
+                                 long defaultValue) {
         super(numBuckets);
 
-        this.maps = new LongIntMap[numBuckets];
+        this.maps = new LongLongMap[numBuckets];
         this.defaultValue = defaultValue;
 
         for (int i = 0; i < numBuckets; i++) {
-            maps[i] = new PrimitiveFastutilLongIntWrapper(initialCapacity, loadFactor, defaultValue);
+            maps[i] = new PrimitiveFastutilLongLongWrapper(initialCapacity, loadFactor, defaultValue);
         }
     }
 
@@ -55,10 +50,10 @@ public class ConcurrentLongIntMap extends PrimitiveConcurrentMap implements Long
     }
 
     @Override
-    public int get(long l) {
+    public long get(long l) {
         int bucket = getBucket(l);
 
-        int result;
+        long result;
 
         Lock readLock = locks[bucket].readLock();
         readLock.lock();
@@ -72,10 +67,10 @@ public class ConcurrentLongIntMap extends PrimitiveConcurrentMap implements Long
     }
 
     @Override
-    public int put(long key, int value) {
+    public long put(long key, long value) {
         int bucket = getBucket(key);
 
-        int result;
+        long result;
 
         Lock writeLock = locks[bucket].writeLock();
         writeLock.lock();
@@ -89,12 +84,12 @@ public class ConcurrentLongIntMap extends PrimitiveConcurrentMap implements Long
     }
 
     @Override
-    public int getDefaultValue() {
+    public long getDefaultValue() {
         return defaultValue;
     }
 
     @Override
-    public int remove(long key) {
+    public long remove(long key) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -107,7 +102,7 @@ public class ConcurrentLongIntMap extends PrimitiveConcurrentMap implements Long
     }
 
     @Override
-    public boolean remove(long key, int value) {
+    public boolean remove(long key, long value) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -120,7 +115,7 @@ public class ConcurrentLongIntMap extends PrimitiveConcurrentMap implements Long
     }
 
     @Override
-    public int computeIfAbsent(long key, Long2IntFunction mappingFunction) {
+    public long computeIfAbsent(long key, Long2LongFunction mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();
@@ -133,7 +128,7 @@ public class ConcurrentLongIntMap extends PrimitiveConcurrentMap implements Long
     }
 
     @Override
-    public int computeIfPresent(long key, BiFunction<Long, Integer, Integer> mappingFunction) {
+    public long computeIfPresent(long key, BiFunction<Long, Long, Long> mappingFunction) {
         int bucket = getBucket(key);
 
         Lock writeLock = locks[bucket].writeLock();

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentLongObjectMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/ConcurrentLongObjectMap.java
@@ -1,0 +1,140 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
+
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongObjectMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongObjectWrapper;
+import it.unimi.dsi.fastutil.longs.Long2ObjectFunction;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.BiFunction;
+
+public class ConcurrentLongObjectMap<V> extends PrimitiveConcurrentMap implements LongObjectMap<V> {
+
+    private final LongObjectMap<V>[] maps;
+    private final V defaultValue;
+
+    public ConcurrentLongObjectMap(int numBuckets, int initialCapacity, float loadFactor, V defaultValue) {
+        super(numBuckets);
+
+        //noinspection unchecked
+        this.maps = new LongObjectMap[numBuckets];
+        this.defaultValue = defaultValue;
+
+        for (int i = 0; i < numBuckets; i++) {
+            maps[i] = new PrimitiveFastutilLongObjectWrapper<>(initialCapacity, loadFactor, defaultValue);
+        }
+    }
+
+    @Override
+    public int size() {
+        return super.size(maps);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return super.isEmpty(maps);
+    }
+
+    @Override
+    public boolean containsKey(long key) {
+        int bucket = getBucket(key);
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            return maps[bucket].containsKey(key);
+        } finally {
+            readLock.unlock();
+        }
+    }
+
+    @Override
+    public V get(long l) {
+        int bucket = getBucket(l);
+
+        V result;
+
+        Lock readLock = locks[bucket].readLock();
+        readLock.lock();
+        try {
+            result = maps[bucket].get(l);
+        } finally {
+            readLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public V put(long key, V value) {
+        int bucket = getBucket(key);
+
+        V result;
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            result = maps[bucket].put(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+
+        return result;
+    }
+
+    @Override
+    public V getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public V remove(long key) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public boolean remove(long key, V value) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].remove(key, value);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public V computeIfAbsent(long key, Long2ObjectFunction<V> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfAbsent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+
+    @Override
+    public V computeIfPresent(long key, BiFunction<Long, V, V> mappingFunction) {
+        int bucket = getBucket(key);
+
+        Lock writeLock = locks[bucket].writeLock();
+        writeLock.lock();
+        try {
+            return maps[bucket].computeIfPresent(key, mappingFunction);
+        } finally {
+            writeLock.unlock();
+        }
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/PrimitiveConcurrentMap.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/map/PrimitiveConcurrentMap.java
@@ -1,4 +1,4 @@
-package com.trivago.fastutilconcurrentwrapper.map;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.map;
 
 import com.trivago.fastutilconcurrentwrapper.KeyMap;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilIntFloatWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilIntFloatWrapper.java
@@ -1,6 +1,6 @@
-package com.trivago.fastutilconcurrentwrapper.wrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper;
 
-import com.trivago.fastutilconcurrentwrapper.IntFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntFloatMap;
 import it.unimi.dsi.fastutil.ints.Int2FloatFunction;
 import it.unimi.dsi.fastutil.ints.Int2FloatOpenHashMap;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilIntIntWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilIntIntWrapper.java
@@ -1,6 +1,6 @@
-package com.trivago.fastutilconcurrentwrapper.wrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper;
 
-import com.trivago.fastutilconcurrentwrapper.IntIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntIntMap;
 import it.unimi.dsi.fastutil.ints.Int2IntFunction;
 import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilIntObjectWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilIntObjectWrapper.java
@@ -1,0 +1,67 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper;
+
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntObjectMap;
+import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+
+import java.util.function.BiFunction;
+
+public class PrimitiveFastutilIntObjectWrapper<V> implements IntObjectMap<V> {
+    private final V defaultValue;
+    private final Int2ObjectOpenHashMap<V> map;
+
+    public PrimitiveFastutilIntObjectWrapper(int initialCapacity, float loadFactor, V defaultValue) {
+        this.defaultValue = defaultValue;
+        this.map = new Int2ObjectOpenHashMap<>(initialCapacity, loadFactor);
+    }
+
+    @Override
+    public V get(int key) {
+        return map.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public V put(int key, V value) {
+        return map.put(key, value);
+    }
+
+    @Override
+    public V getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public V remove(int key) {
+        return map.remove(key);
+    }
+
+    @Override
+    public boolean remove(int key, V value) {
+        return map.remove(key, value);
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean containsKey(int key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public V computeIfAbsent(int key, Int2ObjectFunction<V> mappingFunction) {
+        return map.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public V computeIfPresent(int key, BiFunction<Integer, V, V> mappingFunction) {
+        return map.computeIfPresent(key, mappingFunction);
+    }
+}

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilLongFloatWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilLongFloatWrapper.java
@@ -1,6 +1,6 @@
-package com.trivago.fastutilconcurrentwrapper.wrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper;
 
-import com.trivago.fastutilconcurrentwrapper.LongFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongFloatMap;
 import it.unimi.dsi.fastutil.longs.Long2FloatFunction;
 import it.unimi.dsi.fastutil.longs.Long2FloatOpenHashMap;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilLongIntWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilLongIntWrapper.java
@@ -1,11 +1,8 @@
-package com.trivago.fastutilconcurrentwrapper.wrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper;
 
-import com.trivago.fastutilconcurrentwrapper.LongIntMap;
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongIntMap;
 import it.unimi.dsi.fastutil.longs.Long2IntFunction;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
-import it.unimi.dsi.fastutil.longs.Long2LongFunction;
-import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 
 import java.util.function.BiFunction;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilLongLongWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilLongLongWrapper.java
@@ -1,6 +1,6 @@
-package com.trivago.fastutilconcurrentwrapper.wrapper;
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper;
 
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongLongMap;
 import it.unimi.dsi.fastutil.longs.Long2LongFunction;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 

--- a/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilLongObjectWrapper.java
+++ b/src/main/java/com/trivago/fastutilconcurrentwrapper/primitivekeys/wrapper/PrimitiveFastutilLongObjectWrapper.java
@@ -1,0 +1,71 @@
+package com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper;
+
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongObjectMap;
+import it.unimi.dsi.fastutil.longs.Long2ObjectFunction;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+
+import java.util.function.BiFunction;
+
+public class PrimitiveFastutilLongObjectWrapper<V> implements LongObjectMap<V> {
+    private final Long2ObjectOpenHashMap<V> map;
+    private final V defaultValue;
+
+    public PrimitiveFastutilLongObjectWrapper(int initialCapacity, float loadFactor) {
+        this(initialCapacity, loadFactor, null);
+    }
+
+    public PrimitiveFastutilLongObjectWrapper(int initialCapacity, float loadFactor, V defaultValue) {
+        this.defaultValue = defaultValue;
+        this.map = new Long2ObjectOpenHashMap<>(initialCapacity, loadFactor);
+    }
+
+    @Override
+    public V get(long key) {
+        return map.getOrDefault(key, defaultValue);
+    }
+
+    @Override
+    public V put(long key, V value) {
+        return map.put(key, value);
+    }
+
+    @Override
+    public V getDefaultValue() {
+        return defaultValue;
+    }
+
+    @Override
+    public V remove(long key) {
+        return map.remove(key);
+    }
+
+    @Override
+    public boolean remove(long key, V value) {
+        return map.remove(key, value);
+    }
+
+    @Override
+    public int size() {
+        return map.size();
+    }
+
+    @Override
+    public boolean containsKey(long key) {
+        return map.containsKey(key);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return map.isEmpty();
+    }
+
+    @Override
+    public V computeIfAbsent(long key, Long2ObjectFunction<V> mappingFunction) {
+        return map.computeIfAbsent(key, mappingFunction);
+    }
+
+    @Override
+    public V computeIfPresent(long key, BiFunction<Long, V, V> mappingFunction) {
+        return map.computeIfPresent(key, mappingFunction);
+    }
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/AbstractMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/AbstractMapTest.java
@@ -17,6 +17,10 @@ public abstract class AbstractMapTest {
         return ThreadLocalRandom.current().nextInt();
     }
 
+    protected static ObjectKey nextObject() {
+        return new ObjectKey();
+    }
+
     @Test
     protected abstract void containsKeyReturnsFalseIfMapIsEmpty();
 
@@ -67,4 +71,15 @@ public abstract class AbstractMapTest {
 
     @Test
     protected abstract void checkingValueIfNotPresentReturnsDefaultValue();
+
+    public static class ObjectKey {
+
+        private final int number = nextInt();
+
+        @Override
+        public int hashCode() {
+            return Integer.hashCode(number);
+        }
+
+    }
 }

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentIntFloatMapBuilderTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentIntFloatMapBuilderTest.java
@@ -1,7 +1,9 @@
 package com.trivago.fastutilconcurrentwrapper;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingIntFloatMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentIntFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.ConcurrentIntFloatMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingIntFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentIntFloatMap;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentIntIntMapBuilderTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentIntIntMapBuilderTest.java
@@ -1,7 +1,9 @@
 package com.trivago.fastutilconcurrentwrapper;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingIntIntMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentIntIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.ConcurrentIntIntMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.IntIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingIntIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentIntIntMap;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongFloatMapBuilderTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongFloatMapBuilderTest.java
@@ -1,7 +1,9 @@
 package com.trivago.fastutilconcurrentwrapper;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongFloatMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.ConcurrentLongFloatMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongFloatMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongFloatMap;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongIntMapBuilderTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongIntMapBuilderTest.java
@@ -1,7 +1,9 @@
 package com.trivago.fastutilconcurrentwrapper;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongIntMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.ConcurrentLongIntMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongIntMap;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongLongMapBuilderTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentLongLongMapBuilderTest.java
@@ -1,7 +1,9 @@
 package com.trivago.fastutilconcurrentwrapper;
 
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongLongMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.ConcurrentLongLongMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongLongMap;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentObjectFloatMapBuilderTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentObjectFloatMapBuilderTest.java
@@ -1,0 +1,55 @@
+package com.trivago.fastutilconcurrentwrapper;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ConcurrentObjectFloatMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectFloatMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentBusyWaitingObjectFloatMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentObjectFloatMap;
+import org.junit.jupiter.api.Test;
+
+import static com.trivago.fastutilconcurrentwrapper.AbstractMapTest.nextObject;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+
+public class ConcurrentObjectFloatMapBuilderTest {
+    private final float DEFAULT_VALUE = -1;
+
+    @Test
+    public void simpleBuilderTest() {
+        ConcurrentObjectFloatMapBuilder<AbstractMapTest.ObjectKey> b = ConcurrentObjectFloatMapBuilder.<AbstractMapTest.ObjectKey>newBuilder()
+                .withBuckets(2)
+                .withDefaultValue(DEFAULT_VALUE)
+                .withInitialCapacity(100)
+                .withMode(ConcurrentMapBuilder.MapMode.BUSY_WAITING)
+                .withLoadFactor(0.9f);
+
+        ObjectFloatMap<AbstractMapTest.ObjectKey> map = b.build();
+
+        AbstractMapTest.ObjectKey key = nextObject();
+        map.put(key, 10F);
+        float v = map.get(key);
+
+        assertInstanceOf(ConcurrentBusyWaitingObjectFloatMap.class, map);
+        assertEquals(10F, v);
+        assertEquals(map.get(nextObject()), map.getDefaultValue());
+    }
+
+    @Test
+    public void buildsBlockingMap() {
+        ConcurrentObjectFloatMapBuilder<AbstractMapTest.ObjectKey> b = ConcurrentObjectFloatMapBuilder.<AbstractMapTest.ObjectKey>newBuilder()
+                .withBuckets(2)
+                .withDefaultValue(DEFAULT_VALUE)
+                .withInitialCapacity(100)
+                .withMode(ConcurrentMapBuilder.MapMode.BLOCKING)
+                .withLoadFactor(0.9f);
+
+        ObjectFloatMap<AbstractMapTest.ObjectKey> map = b.build();
+
+        AbstractMapTest.ObjectKey key = nextObject();
+        map.put(key, 10F);
+        float v = map.get(key);
+
+        assertInstanceOf(ConcurrentObjectFloatMap.class, map);
+        assertEquals(10F, v);
+        assertEquals(map.get(nextObject()), map.getDefaultValue());
+    }
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentObjectIntMapBuilderTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentObjectIntMapBuilderTest.java
@@ -1,0 +1,54 @@
+package com.trivago.fastutilconcurrentwrapper;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ConcurrentObjectIntMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectIntMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentBusyWaitingObjectIntMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentObjectIntMap;
+import org.junit.jupiter.api.Test;
+
+import static com.trivago.fastutilconcurrentwrapper.AbstractMapTest.nextObject;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConcurrentObjectIntMapBuilderTest {
+    private final int DEFAULT_VALUE = -1;
+
+    @Test
+    public void simpleBuilderTest() {
+        ConcurrentObjectIntMapBuilder<AbstractMapTest.ObjectKey> b = ConcurrentObjectIntMapBuilder.<AbstractMapTest.ObjectKey>newBuilder()
+                .withBuckets(2)
+                .withDefaultValue(DEFAULT_VALUE)
+                .withInitialCapacity(100)
+                .withMode(ConcurrentMapBuilder.MapMode.BUSY_WAITING)
+                .withLoadFactor(0.9f);
+
+        ObjectIntMap<AbstractMapTest.ObjectKey> map = b.build();
+
+        AbstractMapTest.ObjectKey key = nextObject();
+        map.put(key, 10);
+        int v = map.get(key);
+
+        assertInstanceOf(ConcurrentBusyWaitingObjectIntMap.class, map);
+        assertEquals(10, v);
+        assertEquals(map.get(nextObject()), map.getDefaultValue());
+    }
+
+    @Test
+    public void buildsBlockingMap() {
+        ConcurrentObjectIntMapBuilder<AbstractMapTest.ObjectKey> b = ConcurrentObjectIntMapBuilder.<AbstractMapTest.ObjectKey>newBuilder()
+                .withBuckets(2)
+                .withDefaultValue(DEFAULT_VALUE)
+                .withInitialCapacity(100)
+                .withMode(ConcurrentMapBuilder.MapMode.BLOCKING)
+                .withLoadFactor(0.9f);
+
+        ObjectIntMap<AbstractMapTest.ObjectKey> map = b.build();
+
+        AbstractMapTest.ObjectKey key = nextObject();
+        map.put(key, 10);
+        int v = map.get(key);
+
+        assertInstanceOf(ConcurrentObjectIntMap.class, map);
+        assertEquals(10, v);
+        assertEquals(map.get(nextObject()), map.getDefaultValue());
+    }
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentObjectLongMapBuilderTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/ConcurrentObjectLongMapBuilderTest.java
@@ -1,0 +1,54 @@
+package com.trivago.fastutilconcurrentwrapper;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ConcurrentObjectLongMapBuilder;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectLongMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentBusyWaitingObjectLongMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentObjectLongMap;
+import org.junit.jupiter.api.Test;
+
+import static com.trivago.fastutilconcurrentwrapper.AbstractMapTest.nextObject;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConcurrentObjectLongMapBuilderTest {
+    private final long DEFAULT_VALUE = -1L;
+
+    @Test
+    public void simpleBuilderTest() {
+        ConcurrentObjectLongMapBuilder<AbstractMapTest.ObjectKey> b = ConcurrentObjectLongMapBuilder.<AbstractMapTest.ObjectKey>newBuilder()
+                .withBuckets(2)
+                .withDefaultValue(DEFAULT_VALUE)
+                .withInitialCapacity(100)
+                .withMode(ConcurrentMapBuilder.MapMode.BUSY_WAITING)
+                .withLoadFactor(0.9f);
+
+        ObjectLongMap<AbstractMapTest.ObjectKey> map = b.build();
+
+        AbstractMapTest.ObjectKey key = nextObject();
+        map.put(key, 10L);
+        long v = map.get(key);
+
+        assertInstanceOf(ConcurrentBusyWaitingObjectLongMap.class, map);
+        assertEquals(10L, v);
+        assertEquals(map.get(nextObject()), map.getDefaultValue());
+    }
+
+    @Test
+    public void buildsBlockingMap() {
+        ConcurrentObjectLongMapBuilder<AbstractMapTest.ObjectKey> b = ConcurrentObjectLongMapBuilder.<AbstractMapTest.ObjectKey>newBuilder()
+                .withBuckets(2)
+                .withDefaultValue(DEFAULT_VALUE)
+                .withInitialCapacity(100)
+                .withMode(ConcurrentMapBuilder.MapMode.BLOCKING)
+                .withLoadFactor(0.9f);
+
+        ObjectLongMap<AbstractMapTest.ObjectKey> map = b.build();
+
+        AbstractMapTest.ObjectKey key = nextObject();
+        map.put(key, 10L);
+        long v = map.get(key);
+
+        assertInstanceOf(ConcurrentObjectLongMap.class, map);
+        assertEquals(10L, v);
+        assertEquals(map.get(nextObject()), map.getDefaultValue());
+    }
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longint/AbstractLongIntMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longint/AbstractLongIntMapTest.java
@@ -1,7 +1,7 @@
 package com.trivago.fastutilconcurrentwrapper.longint;
 
 import com.trivago.fastutilconcurrentwrapper.AbstractMapTest;
-import com.trivago.fastutilconcurrentwrapper.LongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongIntMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longint/ConcurrentBusyWaitingLongIntMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longint/ConcurrentBusyWaitingLongIntMapTest.java
@@ -1,7 +1,7 @@
 package com.trivago.fastutilconcurrentwrapper.longint;
 
-import com.trivago.fastutilconcurrentwrapper.LongIntMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongIntMap;
 
 public class ConcurrentBusyWaitingLongIntMapTest extends AbstractLongIntMapTest {
 

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longint/ConcurrentPrimitiveLongIntMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longint/ConcurrentPrimitiveLongIntMapTest.java
@@ -1,7 +1,7 @@
 package com.trivago.fastutilconcurrentwrapper.longint;
 
-import com.trivago.fastutilconcurrentwrapper.LongIntMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongIntMap;
 
 
 public class ConcurrentPrimitiveLongIntMapTest extends AbstractLongIntMapTest {

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longint/PrimitiveFastutilLongIntWrapperTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longint/PrimitiveFastutilLongIntWrapperTest.java
@@ -1,7 +1,7 @@
 package com.trivago.fastutilconcurrentwrapper.longint;
 
-import com.trivago.fastutilconcurrentwrapper.LongIntMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilLongIntWrapper;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongIntWrapper;
 
 public class PrimitiveFastutilLongIntWrapperTest extends AbstractLongIntMapTest {
 

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longlong/AbstractLongLongMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longlong/AbstractLongLongMapTest.java
@@ -1,7 +1,7 @@
 package com.trivago.fastutilconcurrentwrapper.longlong;
 
 import com.trivago.fastutilconcurrentwrapper.AbstractMapTest;
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongLongMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longlong/ConcurrentBusyWaitingLongLongMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longlong/ConcurrentBusyWaitingLongLongMapTest.java
@@ -1,7 +1,7 @@
 package com.trivago.fastutilconcurrentwrapper.longlong;
 
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentBusyWaitingLongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongLongMap;
 
 public class ConcurrentBusyWaitingLongLongMapTest extends AbstractLongLongMapTest {
 

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longlong/ConcurrentLongLongMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longlong/ConcurrentLongLongMapTest.java
@@ -1,7 +1,7 @@
 package com.trivago.fastutilconcurrentwrapper.longlong;
 
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
-import com.trivago.fastutilconcurrentwrapper.map.ConcurrentLongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongLongMap;
 
 public class ConcurrentLongLongMapTest extends AbstractLongLongMapTest {
 

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longlong/PrimitiveFastutilLongLongWrapperTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longlong/PrimitiveFastutilLongLongWrapperTest.java
@@ -1,7 +1,7 @@
 package com.trivago.fastutilconcurrentwrapper.longlong;
 
-import com.trivago.fastutilconcurrentwrapper.LongLongMap;
-import com.trivago.fastutilconcurrentwrapper.wrapper.PrimitiveFastutilLongLongWrapper;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongLongMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongLongWrapper;
 
 public class PrimitiveFastutilLongLongWrapperTest extends AbstractLongLongMapTest {
 

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longobject/AbstractLongObjectMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longobject/AbstractLongObjectMapTest.java
@@ -1,0 +1,209 @@
+package com.trivago.fastutilconcurrentwrapper.longobject;
+
+import com.trivago.fastutilconcurrentwrapper.AbstractMapTest;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongIntMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongObjectMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+abstract class AbstractLongObjectMapTest extends AbstractMapTest {
+
+    protected ObjectKey defaultValue;
+    private LongObjectMap<ObjectKey> map;
+    // Keep the default value to easily verify that this value is returned.
+
+    abstract LongObjectMap<ObjectKey> createMap();
+
+    @BeforeEach
+    void initializeMap() {
+        defaultValue = nextObject();
+        map = createMap();
+    }
+
+    @Test
+    protected void containsKeyReturnsFalseIfMapIsEmpty() {
+        final int key = nextInt();
+
+        final boolean contains = map.containsKey(key);
+
+        assertFalse(contains);
+    }
+
+    @Test
+    protected void containsKeyReturnsTrueIfKeyExists() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        map.put(key, value);
+
+        final boolean contains = map.containsKey(key);
+
+        assertTrue(contains);
+    }
+
+    @Test
+    protected void containsKeyReturnsFalseIfKeyWasRemoved() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        map.put(key, value);
+        map.remove(key);
+
+        final boolean contains = map.containsKey(key);
+
+        assertFalse(contains);
+    }
+
+    @Test
+    protected void mapIsEmptyWhenNothingWasInserted() {
+        final boolean empty = map.isEmpty();
+
+        assertTrue(empty);
+    }
+
+    @Test
+    protected void mapIsEmptyWhenAllKeysAreDeleted() {
+        int entryCount = (Math.abs(nextInt()) % 100) + 1;
+        ObjectKey value = nextObject();
+
+        for (int key = 1; key <= entryCount; key++) {
+            map.put(key, value);
+        }
+        for (int key = 1; key <= entryCount; key++) {
+            map.remove(key);
+        }
+
+        final boolean empty = map.isEmpty();
+
+        assertTrue(empty);
+    }
+
+    @Test
+    protected void sizeIsCorrect() {
+        int entries = (Math.abs(nextInt()) % 50) + 1;
+        ObjectKey value = nextObject();
+
+        for (int key = 1; key <= entries; key++) {
+            map.put(key, value);
+        }
+
+        final int size = map.size();
+
+        assertEquals(entries, size);
+    }
+
+    @Test
+    protected void gettingExistingValueReturnsCorrectValue() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        map.put(key, value);
+        final ObjectKey returnedValue = map.get(key);
+
+        assertEquals(value, returnedValue);
+    }
+
+    @Test
+    protected void gettingNonExistingValueReturnsCorrectValue() {
+        int key = nextInt();
+        final ObjectKey returnedValue = map.get(key);
+
+        assertEquals(defaultValue, returnedValue);
+    }
+
+    @Test
+    protected void removingNonExistingKeyReturnsDefaultValue() {
+        int key = nextInt();
+        final ObjectKey removedValue = map.remove(key);
+
+        assertEquals(null, removedValue);
+    }
+
+    @Test
+    protected void removingExistingKeyReturnsPreviousValue() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        map.put(key, value);
+        final ObjectKey removedValue = map.remove(key);
+
+        assertEquals(value, removedValue);
+    }
+
+    @Test
+    protected void removingWithValueWhenKeyDoesNotExistReturnsFalse() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        final boolean result = map.remove(key, value);
+
+        assertFalse(result);
+    }
+
+    @Test
+    protected void removingWithValueWhenValueIsDifferentReturnsFalse() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        map.put(key, value);
+        final boolean result = map.remove(key, nextObject());
+
+        assertFalse(result);
+    }
+
+    @Test
+    protected void removingWithValueWhenValueIsSameReturnsTrue() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        map.put(key, value);
+        final boolean result = map.remove(key, value);
+
+        assertTrue(result);
+    }
+
+    @Test
+    protected void puttingValueIfAbsentReturnsSameValue() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        map.computeIfAbsent(key, l -> value);
+
+        ObjectKey result = map.get(key);
+
+        assertEquals(result, value);
+    }
+
+    @Test
+    protected void checkingValueIfNotAbsentReturnsSameValue() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        map.put(key, value);
+        ObjectKey returned = map.computeIfAbsent(key, l -> value);
+
+        ObjectKey result = map.get(key);
+
+        assertEquals(result, value);
+        assertEquals(value, returned);
+    }
+
+    @Test
+    protected void replacingValueIfPresentReturnsNewValue() {
+        int key = nextInt();
+        ObjectKey value = nextObject();
+        map.put(key, value);
+
+        ObjectKey newValue = nextObject();
+
+        map.computeIfPresent(key, (aLongKey, anIntValue) -> newValue); // key + old value
+
+        ObjectKey result = map.get(key);
+
+        assertEquals(result, newValue);
+    }
+
+    @Test
+    protected void checkingValueIfNotPresentReturnsDefaultValue() {
+        int key = nextInt();
+        ObjectKey newValue = nextObject();
+        map.computeIfPresent(key, (aLongKey, anIntValue) -> newValue); // key + old value
+
+        ObjectKey result = map.get(key);
+
+        assertEquals(result, map.getDefaultValue());
+    }
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longobject/ConcurrentBusyWaitingLongIntMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longobject/ConcurrentBusyWaitingLongIntMapTest.java
@@ -1,0 +1,12 @@
+package com.trivago.fastutilconcurrentwrapper.longobject;
+
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongObjectMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentBusyWaitingLongObjectMap;
+
+public class ConcurrentBusyWaitingLongIntMapTest extends AbstractLongObjectMapTest {
+
+  @Override
+  LongObjectMap<ObjectKey> createMap() {
+    return new ConcurrentBusyWaitingLongObjectMap<>(16, 16, 0.9F, defaultValue);
+  }
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longobject/ConcurrentPrimitiveLongIntMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longobject/ConcurrentPrimitiveLongIntMapTest.java
@@ -1,0 +1,12 @@
+package com.trivago.fastutilconcurrentwrapper.longobject;
+
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongObjectMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.map.ConcurrentLongObjectMap;
+
+public class ConcurrentPrimitiveLongIntMapTest extends AbstractLongObjectMapTest {
+    @Override
+    LongObjectMap<ObjectKey> createMap() {
+        return new ConcurrentLongObjectMap<>(16, 16, 0.9F, defaultValue);
+    }
+
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/longobject/PrimitiveFastutilLongIntWrapperTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/longobject/PrimitiveFastutilLongIntWrapperTest.java
@@ -1,0 +1,12 @@
+package com.trivago.fastutilconcurrentwrapper.longobject;
+
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.LongObjectMap;
+import com.trivago.fastutilconcurrentwrapper.primitivekeys.wrapper.PrimitiveFastutilLongObjectWrapper;
+
+public class PrimitiveFastutilLongIntWrapperTest extends AbstractLongObjectMapTest {
+
+  @Override
+  LongObjectMap<ObjectKey> createMap() {
+    return new PrimitiveFastutilLongObjectWrapper<>(5, 0.9F, defaultValue);
+  }
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/objectint/AbstractObjectIntMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/objectint/AbstractObjectIntMapTest.java
@@ -1,0 +1,213 @@
+package com.trivago.fastutilconcurrentwrapper.objectint;
+
+import com.trivago.fastutilconcurrentwrapper.AbstractMapTest;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectIntMap;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+abstract class AbstractObjectIntMapTest extends AbstractMapTest {
+    // Some methods return the default value of the underlying Fastutil implementation.
+    private static final int FASTUTIL_DEFAULT_VALUE = 0;
+
+    protected int defaultValue;
+    private ObjectIntMap<ObjectKey> map;
+    // Keep the default value to easily verify that this value is returned.
+
+    abstract ObjectIntMap<ObjectKey> createMap();
+
+    @BeforeEach
+    void initializeMap() {
+        defaultValue = nextInt();
+        map = createMap();
+    }
+
+    @Test
+    protected void containsKeyReturnsFalseIfMapIsEmpty() {
+        final ObjectKey key = nextObject();
+
+        final boolean contains = map.containsKey(key);
+
+        assertFalse(contains);
+    }
+
+    @Test
+    protected void containsKeyReturnsTrueIfKeyExists() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        map.put(key, value);
+
+        final boolean contains = map.containsKey(key);
+
+        assertTrue(contains);
+    }
+
+    @Test
+    protected void containsKeyReturnsFalseIfKeyWasRemoved() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        map.put(key, value);
+        map.remove(key);
+
+        final boolean contains = map.containsKey(key);
+
+        assertFalse(contains);
+    }
+
+    @Test
+    protected void mapIsEmptyWhenNothingWasInserted() {
+        final boolean empty = map.isEmpty();
+
+        assertTrue(empty);
+    }
+
+    @Test
+    protected void mapIsEmptyWhenAllKeysAreDeleted() {
+        int entryCount = (Math.abs(nextInt()) % 100) + 1;
+        int value = nextInt();
+
+        List<ObjectKey> keys = new ArrayList<>(entryCount);
+        for (int key = 1; key <= entryCount; key++) {
+            ObjectKey objectKey = nextObject();
+            keys.add(objectKey);
+            map.put(objectKey, value);
+        }
+        for (ObjectKey objectKey : keys) {
+            map.remove(objectKey);
+        }
+
+        final boolean empty = map.isEmpty();
+
+        assertTrue(empty);
+    }
+
+    @Test
+    protected void sizeIsCorrect() {
+        int entries = (Math.abs(nextInt()) % 50) + 1;
+        int value = nextInt();
+
+        for (int key = 1; key <= entries; key++) {
+            map.put(nextObject(), value);
+        }
+
+        final int size = map.size();
+
+        assertEquals(entries, size);
+    }
+
+    @Test
+    protected void gettingExistingValueReturnsCorrectValue() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        map.put(key, value);
+        final int returnedValue = map.get(key);
+
+        assertEquals(value, returnedValue);
+    }
+
+    @Test
+    protected void gettingNonExistingValueReturnsCorrectValue() {
+        ObjectKey key = nextObject();
+        final int returnedValue = map.get(key);
+
+        assertEquals(defaultValue, returnedValue);
+    }
+
+    @Test
+    protected void removingNonExistingKeyReturnsDefaultValue() {
+        ObjectKey key = nextObject();
+        final int removedValue = map.remove(key);
+
+        assertEquals(FASTUTIL_DEFAULT_VALUE, removedValue);
+    }
+
+    @Test
+    protected void removingExistingKeyReturnsPreviousValue() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        map.put(key, value);
+        final int removedValue = map.remove(key);
+
+        assertEquals(value, removedValue);
+    }
+
+    @Test
+    protected void removingWithValueWhenKeyDoesNotExistReturnsFalse() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        final boolean result = map.remove(key, value);
+
+        assertFalse(result);
+    }
+
+    @Test
+    protected void removingWithValueWhenValueIsDifferentReturnsFalse() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        map.put(key, value);
+        final boolean result = map.remove(key, value - 1);
+
+        assertFalse(result);
+    }
+
+    @Test
+    protected void removingWithValueWhenValueIsSameReturnsTrue() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        map.put(key, value);
+        final boolean result = map.remove(key, value);
+
+        assertTrue(result);
+    }
+
+    @Test
+    protected void puttingValueIfAbsentReturnsSameValue() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        map.computeIfAbsent(key, l -> value);
+
+        int result = map.get(key);
+
+        assertEquals(result, value);
+    }
+
+    @Test
+    protected void checkingValueIfNotAbsentReturnsSameValue() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        map.put(key, value);
+        int returned = map.computeIfAbsent(key, l -> value);
+
+        int result = map.get(key);
+
+        assertEquals(result, value);
+        assertEquals(value, returned);
+    }
+
+    @Test
+    protected void replacingValueIfPresentReturnsNewValue() {
+        ObjectKey key = nextObject();
+        int value = nextInt();
+        map.put(key, value);
+
+        map.computeIfPresent(key, (aLongKey, anIntValue) -> 2 * anIntValue); // key + old value
+
+        int result = map.get(key);
+
+        assertEquals(result, 2 * value);
+    }
+
+    @Test
+    protected void checkingValueIfNotPresentReturnsDefaultValue() {
+        ObjectKey key = nextObject();
+        map.computeIfPresent(key, (aLongKey, anIntValue) -> 2 * anIntValue); // key + old value
+
+        int result = map.get(key);
+
+        assertEquals(result, map.getDefaultValue());
+    }
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/objectint/ConcurrentBusyWaitingObjectIntMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/objectint/ConcurrentBusyWaitingObjectIntMapTest.java
@@ -1,0 +1,12 @@
+package com.trivago.fastutilconcurrentwrapper.objectint;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectIntMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentBusyWaitingObjectIntMap;
+
+public class ConcurrentBusyWaitingObjectIntMapTest extends AbstractObjectIntMapTest {
+
+  @Override
+  ObjectIntMap<ObjectKey> createMap() {
+    return new ConcurrentBusyWaitingObjectIntMap<>(16, 16, 0.9F, defaultValue);
+  }
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/objectint/ConcurrentPrimitiveObjectIntMapTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/objectint/ConcurrentPrimitiveObjectIntMapTest.java
@@ -1,0 +1,12 @@
+package com.trivago.fastutilconcurrentwrapper.objectint;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectIntMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.map.ConcurrentObjectIntMap;
+
+public class ConcurrentPrimitiveObjectIntMapTest extends AbstractObjectIntMapTest {
+    @Override
+    ObjectIntMap<ObjectKey> createMap() {
+        return new ConcurrentObjectIntMap<>(16, 16, 0.9F, defaultValue);
+    }
+
+}

--- a/src/test/java/com/trivago/fastutilconcurrentwrapper/objectint/PrimitiveFastutilObjectIntWrapperTest.java
+++ b/src/test/java/com/trivago/fastutilconcurrentwrapper/objectint/PrimitiveFastutilObjectIntWrapperTest.java
@@ -1,0 +1,12 @@
+package com.trivago.fastutilconcurrentwrapper.objectint;
+
+import com.trivago.fastutilconcurrentwrapper.objectkeys.ObjectIntMap;
+import com.trivago.fastutilconcurrentwrapper.objectkeys.wrapper.PrimitiveFastutilObjectIntWrapper;
+
+public class PrimitiveFastutilObjectIntWrapperTest extends AbstractObjectIntMapTest {
+
+  @Override
+  ObjectIntMap<ObjectKey> createMap() {
+    return new PrimitiveFastutilObjectIntWrapper<>(5, 0.9F, defaultValue);
+  }
+}


### PR DESCRIPTION
This PR adds primitive support for maps using objects in either the keys or values.
The performance benefits are still clearly there, while providing less memory usage.

**Other changes:**
- The readme has been modified to show performance benchmark results for object keys.
- Added [ConcurrentMap](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentMap.html) comparison in JMH benchmark. Since its also a viable alternative _(when not considering memory)_.
- Cleaned up the builder code to reduce DRY

This PR drastically changes the structure of the code, and would require a major version change.